### PR TITLE
Pin pip version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,3 @@ dependencies:
   - dill
   - xrootd
   - git
-  - pip=22.0.4


### PR DESCRIPTION
This PR temporarily pins the pip version as suggested by @klannon. This temporary fix (which is applied in `remote_environment.py`) is to work around the current pip/poncho incompatibility documented [here](https://github.com/cooperative-computing-lab/cctools/issues/2856). Once that issue is resolved, we should un pin the version as mentioned in #266. 