### PR TITLE
HistEft to scikit hist

### DIFF
--- a/analysis/topEFT/fullR2_run.sh
+++ b/analysis/topEFT/fullR2_run.sh
@@ -4,7 +4,13 @@
 OUT_NAME="example_name"
 
 # Build the run command for filling SR histos
-CFGS="../../topcoffea/cfg/mc_signal_samples_NDSkim.cfg,../../topcoffea/cfg/mc_background_samples_NDSkim.cfg,../../topcoffea/cfg/data_samples_NDSkim.cfg"
+# CFGS="../../topcoffea/cfg/mc_signal_samples_NDSkim.cfg,../../topcoffea/cfg/mc_background_samples_NDSkim.cfg,../../topcoffea/cfg/data_samples_NDSkim.cfg"
+CFGS="cfg_vast_ndcms/onefile.cfg"
+CFGS="cfg_vast_ndcms/d2018.cfg"
+CFGS="cfg_vast_ndcms/50files.cfg"
+CFGS="cfg_vast_ndcms/25bfiles.cfg"
+CFGS="cfg_vast_ndcms/25files.cfg"
+
 OPTIONS="--hist-list ana --skip-cr --do-systs -s 50000 --do-np -o $OUT_NAME" # For analysis
 
 # Build the run command for filling CR histos

--- a/analysis/topEFT/make_cards.py
+++ b/analysis/topEFT/make_cards.py
@@ -158,7 +158,7 @@ def main():
     parser.add_argument("--var-lst",default=[],action="extend",nargs="+",help="Specify a list of variables to make cards for.")
     parser.add_argument("--ch-lst","-c",default=[],action="extend",nargs="+",help="Specify a list of channels to process.")
     parser.add_argument("--do-mc-stat",action="store_true",help="Add bin-by-bin statistical uncertainties with the autoMCstats option (for background)")
-    parser.add_argument("--ignore","-i",default=[],action="extend",nargs="+",help="Specify a list of processes to exclude, must match name from 'sample' axis modulo UL year")
+    parser.add_argument("--ignore","-i",default=[],action="extend",nargs="+",help="Specify a list of processes to exclude, must match name from 'process' axis modulo UL year")
     parser.add_argument("--drop-syst",default=[],action="extend",nargs="+",help="Specify one or more template systematics to remove from the datacard")
     parser.add_argument("--POI",default=[],help="List of WCs (comma separated)")
     parser.add_argument("--year","-y",default=[],action="extend",nargs="+",help="Run over a subset of years")

--- a/analysis/topEFT/make_cr_and_sr_plots.py
+++ b/analysis/topEFT/make_cr_and_sr_plots.py
@@ -6,8 +6,7 @@ import argparse
 import matplotlib.pyplot as plt
 from cycler import cycler
 
-from coffea import hist
-#from topcoffea.modules.HistEFT import HistEFT
+import hist
 
 from topcoffea.modules.YieldTools import YieldTools
 import topcoffea.modules.GetValuesFromJsons as getj
@@ -182,9 +181,7 @@ def group_bins(histo,bin_map,axis_name="sample",drop_unspecified=False):
                 bin_map[bin_name] = bin_name
 
     # Remap the bins
-    old_ax = histo.axis(axis_name)
-    new_ax = hist.Cat(old_ax.name,old_ax.label)
-    new_histo = histo.group(old_ax,new_ax,bin_map,overflow="over")
+    new_histo = histo.group(axis_name, axis_name, bin_map)
 
     return new_histo
 
@@ -478,8 +475,7 @@ def make_cr_fig(h_mc,h_data,unit_norm_bool,set_x_lim=None,err_p=None,err_m=None,
         h_data.scale(1.0/sum_data)
 
     # Plot the MC
-    hist.plot1d(
-        h_mc,
+    h_mc.plot1d(
         ax=ax,
         stack=True,
         line_opts=None,
@@ -489,8 +485,7 @@ def make_cr_fig(h_mc,h_data,unit_norm_bool,set_x_lim=None,err_p=None,err_m=None,
     )
 
     # Plot the data
-    hist.plot1d(
-        h_data,
+    h_data.plot1d(
         ax=ax,
         error_opts = DATA_ERR_OPS,
         stack=False,
@@ -535,8 +530,7 @@ def make_cr_fig(h_mc,h_data,unit_norm_bool,set_x_lim=None,err_p=None,err_m=None,
 def make_single_fig(histo,unit_norm_bool):
     #print("\nPlotting values:",histo.values())
     fig, ax = plt.subplots(1, 1, figsize=(7,7))
-    hist.plot1d(
-        histo,
+    histo.plot1d(
         stack=False,
         density=unit_norm_bool,
         clear=False,
@@ -560,8 +554,7 @@ def make_single_fig_with_ratio(histo,axis_name,cat_ref,err_p=None,err_m=None,err
     fig.subplots_adjust(hspace=.07)
 
     # Make the main plot
-    hist.plot1d(
-        histo,
+    histo.plot1d(
         ax=ax,
         stack=False,
         clear=False,

--- a/analysis/topEFT/run_topeft.py
+++ b/analysis/topEFT/run_topeft.py
@@ -8,8 +8,9 @@ import gzip
 import os
 
 import numpy as np
-from coffea import hist, processor
+from coffea import processor
 from coffea.nanoevents import NanoAODSchema
+import hist
 
 import topeft
 import topcoffea.modules.utils as utils
@@ -331,8 +332,8 @@ if __name__ == '__main__':
     if executor == "work_queue":
         print('Processed {} events in {} seconds ({:.2f} evts/sec).'.format(nevts_total,dt,nevts_total/dt))
 
-    nbins = sum(sum(arr.size for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))
-    nfilled = sum(sum(np.sum(arr > 0) for arr in h._sumw.values()) for h in output.values() if isinstance(h, hist.Hist))
+    nbins = sum(sum(arr.size for arr in h.view()) for h in output.values() if isinstance(h, hist.BaseHist))
+    nfilled = sum(sum(np.sum(arr > 0) for arr in h.view()) for h in output.values() if isinstance(h, hist.BaseHist))
     print("Filled %.0f bins, nonzero bins: %1.1f %%" % (nbins, 100*nfilled/nbins,))
 
     if executor == "futures":

--- a/analysis/topEFT/run_topeft.py
+++ b/analysis/topEFT/run_topeft.py
@@ -258,6 +258,8 @@ if __name__ == '__main__':
             'environment_file': remote_environment.get_environment(),
             'extra_input_files': ["topeft.py"],
 
+            'filepath': f'/project01/ndcms/{os.environ["USER"]}',
+
             'retries': 5,
 
             # use mid-range compression for chunks results. 9 is the default for work

--- a/analysis/topEFT/run_topeft.py
+++ b/analysis/topEFT/run_topeft.py
@@ -263,7 +263,7 @@ if __name__ == '__main__':
             # use mid-range compression for chunks results. 9 is the default for work
             # queue in coffea. Valid values are 0 (minimum compression, less memory
             # usage) to 16 (maximum compression, more memory usage).
-            'compression': 9,
+            'compression': 4,
 
             # automatically find an adequate resource allocation for tasks.
             # tasks are first tried using the maximum resources seen of previously ran

--- a/analysis/topEFT/run_topeft.py
+++ b/analysis/topEFT/run_topeft.py
@@ -334,7 +334,7 @@ if __name__ == '__main__':
 
     nbins = sum(sum(arr.size for arr in h.view()) for h in output.values() if isinstance(h, hist.BaseHist))
     nfilled = sum(sum(np.sum(arr > 0) for arr in h.view()) for h in output.values() if isinstance(h, hist.BaseHist))
-    print("Filled %.0f bins, nonzero bins: %1.1f %%" % (nbins, 100*nfilled/nbins,))
+    print("Filled %.0f bins, nonzero bins: %1.1f %%" % (nbins, 100*nfilled/max(1, nbins),))
 
     if executor == "futures":
         print("Processing time: %1.2f s with %i workers (%.2f s cpu overall)" % (dt, nworkers, dt*nworkers, ))

--- a/analysis/topEFT/run_topeft.py
+++ b/analysis/topEFT/run_topeft.py
@@ -334,8 +334,8 @@ if __name__ == '__main__':
     if executor == "work_queue":
         print('Processed {} events in {} seconds ({:.2f} evts/sec).'.format(nevts_total,dt,nevts_total/dt))
 
-    nbins = sum(sum(arr.size for arr in h.view()) for h in output.values() if isinstance(h, hist.BaseHist))
-    nfilled = sum(sum(np.sum(arr > 0) for arr in h.view()) for h in output.values() if isinstance(h, hist.BaseHist))
+    nbins = sum(sum(arr.size for arr in h.view().values()) for h in output.values() if isinstance(h, hist.BaseHist))
+    nfilled = sum(sum(np.sum(arr > 0) for arr in h.view().values()) for h in output.values() if isinstance(h, hist.BaseHist))
     print("Filled %.0f bins, nonzero bins: %1.1f %%" % (nbins, 100*nfilled/max(1, nbins),))
 
     if executor == "futures":

--- a/analysis/topEFT/topeft.py
+++ b/analysis/topEFT/topeft.py
@@ -224,7 +224,6 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Check to see if the ordering of WCs for this sample matches what want
             if self._samples[dataset]["WCnames"] != self._wc_names_lst:
                 eft_coeffs = efth.remap_coeffs(self._samples[dataset]["WCnames"], self._wc_names_lst, eft_coeffs)
-        eft_w2_coeffs = efth.calc_w2_coeffs(eft_coeffs,self._dtype) if (self._do_errors and eft_coeffs is not None) else None
         # Initialize the out object
         hout = self.accumulator.identity()
 
@@ -889,7 +888,6 @@ class AnalysisProcessor(processor.ProcessorABC):
                                         # Weights and eft coeffs
                                         weights_flat = weight[all_cuts_mask]
                                         eft_coeffs_cut = eft_coeffs[all_cuts_mask] if eft_coeffs is not None else None
-                                        eft_w2_coeffs_cut = eft_w2_coeffs[all_cuts_mask] if eft_w2_coeffs is not None else None
 
 
                                         # Fill the histos
@@ -901,7 +899,6 @@ class AnalysisProcessor(processor.ProcessorABC):
                                             "systematic"    : wgt_fluct,
                                             "weight"        : weights_flat,
                                             "eft_coeff"     : eft_coeffs_cut,
-                                            "eft_err_coeff" : eft_w2_coeffs_cut,
                                         }
 
                                         # Skip histos that are not defined (or not relevant) to given categories

--- a/tests/test_HistEFT_add.py
+++ b/tests/test_HistEFT_add.py
@@ -173,6 +173,17 @@ def test_group():
     )
 
 
+def test_union():
+    ab = a_w + b_w
+    abu = a_w.union(b_w, "type")
+
+    for sk in ab.sparse_keys():
+        assert np.all(np.abs(ab[sk].view(flow=True)) - abu[sk].view(flow=True) < 1e-10)
+
+    for sk in abu.sparse_keys():
+        assert np.all(np.abs(ab[sk].view(flow=True)) - abu[sk].view(flow=True) < 1e-10)
+
+
 def test_add_ab_weights():
     ab = a_w + b_w
     assert np.all(

--- a/tests/test_HistEFT_add.py
+++ b/tests/test_HistEFT_add.py
@@ -3,6 +3,8 @@ import hist
 from topcoffea.modules.histEFT import HistEFT
 import topcoffea.modules.eft_helper as efth
 
+import awkward as ak
+
 # Let's generate some fake data to use for testing
 wc_names_lst = [
     "cpt",
@@ -44,57 +46,12 @@ a = HistEFT(
     wc_names=wc_names_lst,
 )
 
-# Just need another one like the one above
-b = HistEFT(
-    hist.axis.StrCategory([], name="type", label="type", growth=True),
-    hist.axis.Regular(1, 0, 1, name="x", label="x"),
-    wc_names=wc_names_lst,
-    label="Events",
-)
+# Just need another one where I won't fill the EFT coefficients
+b = a.copy()
 
 # Fill the EFT histogram
-a.fill(type="eft_a", x=np.full(nevts, 0.5), eft_coeff=eft_fit_coeffs)
-b.fill(type="eft_b", x=np.full(nevts, 0.5), eft_coeff=eft_one_coeffs)
-
-
-def test_add_ab_noerrors():
-    ab = a + b
-    assert np.all(ab.integrate("type", "eft_a").view(flow=False)[0] == sums)
-    assert np.all(ab.integrate("type", "eft_b").view(flow=False)[0] == nevts)
-
-
-def test_add_ba_noerrors():
-    ba = a + b
-    assert np.all(ba.integrate("type", "eft_a").view(flow=False)[0] == sums)
-    assert np.all(ba.integrate("type", "eft_b").view(flow=False)[0] == nevts)
-
-
-def test_add_aba_noerrors():
-    ab = a + b
-    aba = ab + a
-    assert np.all(aba.integrate("type", "eft_a").view(flow=False)[0] == 2 * sums)
-    assert np.all(aba.integrate("type", "eft_b").view(flow=False)[0] == nevts)
-
-
-def test_add_baa_noerrors():
-    ba = b + a
-    baa = ba + a
-    assert np.all(baa.integrate("type", "eft_a").view(flow=False)[0] == 2 * sums)
-    assert np.all(baa.integrate("type", "eft_b").view(flow=False)[0] == nevts)
-
-
-def test_add_abb_noerrors():
-    ab = a + b
-    abb = ab + b
-    assert np.all(abb.integrate("type", "eft_a").view(flow=False)[0] == sums)
-    assert np.all(abb.integrate("type", "eft_b").view(flow=False)[0] == 2 * nevts)
-
-
-def test_add_bab_noerrors():
-    ba = b + a
-    bab = ba + b
-    assert np.all(bab.integrate("type", "eft_a").view(flow=False)[0] == sums)
-    assert np.all(bab.integrate("type", "eft_b").view(flow=False)[0] == 2 * nevts)
+a.fill(type="eft", x=np.full(nevts, 0.5), eft_coeff=eft_fit_coeffs)
+b.fill(type="non-eft", x=np.full(nevts, 0.5))
 
 
 a_w = HistEFT(
@@ -104,103 +61,116 @@ a_w = HistEFT(
     wc_names=wc_names_lst,
 )
 
-# Just need another one like the one above
-b_w = HistEFT(
-    hist.axis.StrCategory([], name="type", label="type", growth=True),
-    hist.axis.Regular(1, 0, 1, name="x", label="x"),
-    label="Events",
-    wc_names=wc_names_lst,
-)
+# Just need another one where I won't fill the EFT coefficients
+b_w = a_w.copy()
 
 # Fill the EFT histogram
 weight_val = 0.9
 a_w.fill(
-    type="eft_a",
+    type="eft",
     x=np.full(nevts, 0.5),
     eft_coeff=eft_fit_coeffs,
     weight=np.full(nevts, weight_val),
 )
-b_w.fill(
-    type="eft_b",
-    x=np.full(nevts, 0.5),
-    eft_coeff=eft_one_coeffs,
-    weight=np.full(nevts, weight_val),
-)
+b_w.fill(type="non-eft", x=np.full(nevts, 0.5), weight=np.full(nevts, weight_val))
 
 
 def test_scale_a_weights():
-    ones = dict(zip(wc_names_lst, np.ones(wc_count)))
-    zeros = dict(zip(wc_names_lst, np.zeros(wc_count)))
-
-    intf = a_w.integrate("type", "eft_a").view(flow=True)[1]
-    assert intf[0] == 0
-    assert intf[-1] == 0
-    assert np.all(np.abs(intf[1:-1] - weight_val * sums) < 1e-10)  # drop under and overflow bins
-
-    integral = a_w.integrate("type", "eft_a").eval({})[()]
     assert np.all(
-        np.abs(
-            a_w.integrate("type", "eft_a").eval(zeros)[()] == integral
-        )
+        np.abs(a_w.integrate("type", "eft").view(as_dict=True)[()][0] - weight_val * sums) < 1e-10
     )
-
-    assert np.any(
-        np.abs(
-            a_w.integrate("type", "eft_a").eval(ones)[()] != integral
-        )
+    integral = a_w.integrate("type", "eft").view(as_dict=True)[()].sum()
+    a_w.set_wilson_coeff_from_array(np.ones(a_w._nwc))
+    assert a_w.integrate("type", "eft").view(as_dict=True)[()].sum() != integral
+    assert np.all(
+        np.abs(a_w.integrate("type", "eft").view(as_dict=True)[()][0] - weight_val * sums) < 1e-10
     )
-
-    a_w.integrate("type", "eft_a").eval(ones)[()].sum() - weight_val * sums.sum() < 1e-10
+    ones = dict(zip(wc_names_lst, np.ones(a_w._nwc)))
+    a_w.set_wilson_coefficients(**ones)
+    assert (
+        a_w.integrate("type", "eft").view(as_dict=True)[()].sum() != integral
+    )  # FIXME we should compute the actual values
+    a_w.set_sm()
+    assert a_w.integrate("type", "eft").view(as_dict=True)[()].sum() == integral
 
 
 def test_ac_deepcopy():
-    c_w = a_w.copy(deep=True)
+    c_w = a_w.copy()
+
     assert np.all(
-        a_w.integrate("type", "eft_a").view(flow=False)[0] == c_w.integrate("type", "eft_a").view(flow=False)[0]
+        a_w.integrate("type", "eft").view(as_dict=True)[()] == c_w.integrate("type", "eft").view(as_dict=True)[()]
     )
     c_w.scale(1)
     c_w.reset()
-    assert np.all(c_w.view(flow=False)[0] == 0)
+
+    assert ak.sum(a_w.values()) != 0
+    assert ak.sum(c_w.values()) == 0
 
 
 def test_group():
-    ab = a + b
-    c = ab.group("type", "all", {"efts": ["eft_a", "eft_b"]})
+    c_w = a_w.group("type", hist.Cat("all", "all"), {"all": ["eft", "non-eft"]})
     assert (
-        c.integrate("all", "efts").eval({})[()].sum()
-        == a.integrate("type", "eft_a").eval({})[()].sum()
-        + b.integrate("type", "eft_b").eval({})[()].sum()
+        c_w.integrate("all").view(as_dict=True)[()].sum()
+        == a_w.integrate("type").view(as_dict=True)[()].sum()
     )
 
 
-def test_union():
-    ab = a_w + b_w
-    abu = a_w.union(b_w, "type")
+def test_add_ab_noerrors():
+    ab = a + b
+    assert np.all(ab.integrate("type", "eft").view(as_dict=True)[()][0] == sums)
+    assert ab.integrate("type", "non-eft").view(as_dict=True)[()][0] == nevts
 
-    for sk in ab.sparse_keys():
-        assert np.all(np.abs(ab[sk].view(flow=True)) - abu[sk].view(flow=True) < 1e-10)
 
-    for sk in abu.sparse_keys():
-        assert np.all(np.abs(ab[sk].view(flow=True)) - abu[sk].view(flow=True) < 1e-10)
+def test_add_ba_noerrors():
+    ba = b + a
+    assert np.all(ba.integrate("type", "eft").view(as_dict=True)[()][0] == sums)
+    assert ba.integrate("type", "non-eft").view(as_dict=True)[()][0] == nevts
+
+
+def test_add_aba_noerrors():
+    ab = a + b
+    aba = ab + a
+    assert np.all(aba.integrate("type", "eft").view(as_dict=True)[()][0] == 2 * sums)
+    assert aba.integrate("type", "non-eft").view(as_dict=True)[()][0] == nevts
+
+
+def test_add_baa_noerrors():
+    ba = b + a
+    baa = ba + a
+    assert np.all(baa.integrate("type", "eft").view(as_dict=True)[()][0] == 2 * sums)
+    assert baa.integrate("type", "non-eft").view(as_dict=True)[()][0] == nevts
+
+
+def test_add_abb_noerrors():
+    ab = a + b
+    abb = ab + b
+    assert np.all(abb.integrate("type", "eft").view(as_dict=True)[()][0] == sums)
+    assert abb.integrate("type", "non-eft").view(as_dict=True)[()][0] == 2 * nevts
+
+
+def test_add_bab_noerrors():
+    ba = b + a
+    bab = ba + b
+    assert np.all(bab.integrate("type", "eft").view(as_dict=True)[()][0] == sums)
 
 
 def test_add_ab_weights():
     ab = a_w + b_w
     assert np.all(
-        np.abs(ab.integrate("type", "eft_a").view(flow=False)[0] - weight_val * sums) < 1e-10
+        np.abs(ab.integrate("type", "eft").view(as_dict=True)[()][0] - weight_val * sums) < 1e-10
     )
-    assert np.all(
-        np.abs(ab.integrate("type", "eft_b").view(flow=False)[0] - nevts * weight_val) < 1e-10
+    assert (
+        abs(ab.integrate("type", "non-eft").view(as_dict=True)[()][0] - nevts * weight_val) < 1e-10
     )
 
 
 def test_add_ba_weights():
     ba = b_w + a_w
     assert np.all(
-        np.abs(ba.integrate("type", "eft_a").view(flow=False)[0] - weight_val * sums) < 1e-10
+        np.abs(ba.integrate("type", "eft").view(as_dict=True)[()][0] - weight_val * sums) < 1e-10
     )
-    assert np.all(
-        np.abs(ba.integrate("type", "eft_b").view(flow=False)[0] - nevts * weight_val) < 1e-10
+    assert (
+        abs(ba.integrate("type", "non-eft").view(as_dict=True)[()][0] - nevts * weight_val) < 1e-10
     )
 
 
@@ -208,10 +178,11 @@ def test_add_aba_weights():
     ab = a_w + b_w
     aba = ab + a_w
     assert np.all(
-        np.abs(aba.integrate("type", "eft_a").view(flow=False)[0] - 2 * weight_val * sums) < 1e-10
+        np.abs(aba.integrate("type", "eft").view(as_dict=True)[()][0] - 2 * weight_val * sums)
+        < 1e-10
     )
-    assert np.all(
-        np.abs(aba.integrate("type", "eft_b").view(flow=False)[0] - nevts * weight_val) < 1e-10
+    assert (
+        abs(aba.integrate("type", "non-eft").view(as_dict=True)[()][0] - nevts * weight_val) < 1e-10
     )
 
 
@@ -219,10 +190,11 @@ def test_add_baa_weights():
     ba = b_w + a_w
     baa = ba + a_w
     assert np.all(
-        np.abs(baa.integrate("type", "eft_a").view(flow=False)[0] - 2 * weight_val * sums) < 1e-10
+        np.abs(baa.integrate("type", "eft").view(as_dict=True)[()][0] - 2 * weight_val * sums)
+        < 1e-10
     )
-    assert np.all(
-        np.abs(baa.integrate("type", "eft_b").view(flow=False)[0] - nevts * weight_val) < 1e-10
+    assert (
+        abs(baa.integrate("type", "non-eft").view(as_dict=True)[()][0] - nevts * weight_val) < 1e-10
     )
 
 
@@ -230,10 +202,11 @@ def test_add_abb_weights():
     ab = a_w + b_w
     abb = ab + b_w
     assert np.all(
-        np.abs(abb.integrate("type", "eft_a").view(flow=False)[0] - weight_val * sums) < 1e-10
+        np.abs(abb.integrate("type", "eft").view(as_dict=True)[()][0] - weight_val * sums) < 1e-10
     )
-    assert np.all(
-        np.abs(abb.integrate("type", "eft_b").view(flow=False)[0] - 2 * nevts * weight_val) < 1e-10
+    assert (
+        abs(abb.integrate("type", "non-eft").view(as_dict=True)[()][0] - 2 * nevts * weight_val)
+        < 1e-10
     )
 
 
@@ -241,14 +214,20 @@ def test_add_bab_weights():
     ba = b_w + a_w
     bab = ba + b_w
     assert np.all(
-        np.abs(bab.integrate("type", "eft_a").view(flow=False)[0] - weight_val * sums) < 1e-10
+        np.abs(bab.integrate("type", "eft").view(as_dict=True)[()][0] - weight_val * sums) < 1e-10
     )
-    assert np.all(
-        np.abs(bab.integrate("type", "eft_b").view(flow=False)[0] - 2 * nevts * weight_val) < 1e-10
+    assert (
+        abs(bab.integrate("type", "non-eft").view(as_dict=True)[()][0] - 2 * nevts * weight_val)
+        < 1e-10
     )
 
 
 def test_split_by_terms():
-    integral = a[{'type': sum}]
-    c = a.split_by_terms(['x'], 'type')
-    assert integral == c.integrate('type', [k[0] for k in c.view(flow=True) if 'eft' not in k[0]]).view(flow=True)[()].sum()
+    integral = a.sum("type").view(as_dict=True)[()].sum()
+    c = a.split_by_terms(["x"], "type")
+    assert (
+        integral
+        == c.integrate("type", [k[0] for k in c.view(as_dict=True) if "eft" not in k[0]])
+        .view(as_dict=True)[()]
+        .sum()
+    )

--- a/tests/test_HistEFT_add.py
+++ b/tests/test_HistEFT_add.py
@@ -106,10 +106,13 @@ def test_ac_deepcopy():
 
 
 def test_group():
-    c_w = a_w.group("type", "all", {"all": ["eft", "non-eft"]})
+    c_w = a_w + b_w
+    g_w = c_w.group("type", {"all": ["eft", "non-eft"]})
+
+    print(g_w._dense_hists)
     assert (
-        c_w.integrate("all").view(as_dict=True)[()].sum()
-        == a_w.integrate("type").view(as_dict=True)[()].sum()
+        g_w.integrate("type").view(as_dict=True)[()].sum()
+        == c_w.integrate("type").view(as_dict=True)[()].sum()
     )
 
 

--- a/tests/test_HistEFT_add.py
+++ b/tests/test_HistEFT_add.py
@@ -1,14 +1,9 @@
 import numpy as np
-from coffea import hist
-from topcoffea.modules.HistEFT import HistEFT
+import hist
+from topcoffea.modules.histEFT import HistEFT
 import topcoffea.modules.eft_helper as efth
 
 # Let's generate some fake data to use for testing
-nevts = 1000
-rng = np.random.default_rng()
-eft_fit_coeffs = rng.normal(0.3, 0.5, (nevts,276))
-sums = np.sum(eft_fit_coeffs, axis=0)
-
 wc_names_lst = [
     "cpt",
     "ctp",
@@ -34,210 +29,215 @@ wc_names_lst = [
     "ctG"
 ]
 
+nevts = 1000
+wc_count = len(wc_names_lst)
+ncoeffs = efth.n_quad_terms(wc_count)
+rng = np.random.default_rng()
+eft_fit_coeffs = rng.normal(0.3, 0.5, (nevts, ncoeffs))
+eft_one_coeffs = np.ones((nevts, ncoeffs))
+sums = np.sum(eft_fit_coeffs, axis=0)
+
 a = HistEFT(
-    "Events",
-    wc_names_lst,
-    hist.Cat("type", "type"),
-    hist.Bin("x",  "x", 1, 0, 1)
+    hist.axis.StrCategory([], name="type", label="type", growth=True),
+    hist.axis.Regular(1, 0, 1, name="x", label="x"),
+    label="Events",
+    wc_names=wc_names_lst,
 )
-# Just need another one where I won't fill the EFT coefficients
-b = a.copy(content=False)
+
+# Just need another one like the one above
+b = HistEFT(
+    hist.axis.StrCategory([], name="type", label="type", growth=True),
+    hist.axis.Regular(1, 0, 1, name="x", label="x"),
+    wc_names=wc_names_lst,
+    label="Events",
+)
 
 # Fill the EFT histogram
-a.fill(type='eft', x=np.full(nevts,0.5), eft_coeff=eft_fit_coeffs)
-b.fill(type='non-eft', x=np.full(nevts,0.5))
+a.fill(type="eft_a", x=np.full(nevts, 0.5), eft_coeff=eft_fit_coeffs)
+b.fill(type="eft_b", x=np.full(nevts, 0.5), eft_coeff=eft_one_coeffs)
 
-def test_scale_a_weights():
-    assert np.all(np.abs(a_w.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
-    integral = a_w.integrate('type','eft').values()[()].sum()
-    a_w.set_wilson_coeff_from_array(np.ones(a_w._nwc))
-    assert a_w.integrate('type','eft').values()[()].sum() != integral
-    assert np.all(np.abs(a_w.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
-    ones = dict(zip(wc_names_lst, np.ones(a_w._nwc)))
-    a_w.set_wilson_coefficients(**ones)
-    assert a_w.integrate('type','eft').values()[()].sum() != integral #FIXME we should compute the actual values
-    a_w.set_sm()
-    assert a_w.integrate('type','eft').values()[()].sum() == integral
-
-def test_ac_deepcopy():
-    c_w = a_w.copy(content=True)
-    assert np.all(a_w.integrate('type','eft')._sumw[()] == c_w.integrate('type','eft')._sumw[()])
-    c_w.scale(1)
-    c_w.clear()
-    assert c_w._sumw == {}
-    assert c_w._sumw2 ==  None
-
-def test_group():
-    c_w = a_w.group('type', hist.Cat('all', 'all'), {'all': ['eft', 'non-eft']})
-    assert c_w.integrate('all').values()[()].sum() == a_w.integrate('type').values()[()].sum()
 
 def test_add_ab_noerrors():
     ab = a + b
-    assert np.all(ab.integrate('type','eft')._sumw[()][1] == sums)
-    assert ab.integrate('type','eft')._sumw2 is None
-    assert ab.integrate('type','non-eft')._sumw[()][1] == nevts
-    assert ab.integrate('type','non-eft')._sumw2 is None
+    assert np.all(ab.integrate("type", "eft_a").view(flow=False)[0] == sums)
+    assert np.all(ab.integrate("type", "eft_b").view(flow=False)[0] == nevts)
+
 
 def test_add_ba_noerrors():
-    ba = b + a
-    assert np.all(ba.integrate('type','eft')._sumw[()][1] == sums)
-    assert ba.integrate('type','eft')._sumw2 is None
-    assert ba.integrate('type','non-eft')._sumw[()][1] == nevts
-    assert ba.integrate('type','non-eft')._sumw2 is None
+    ba = a + b
+    assert np.all(ba.integrate("type", "eft_a").view(flow=False)[0] == sums)
+    assert np.all(ba.integrate("type", "eft_b").view(flow=False)[0] == nevts)
+
 
 def test_add_aba_noerrors():
     ab = a + b
     aba = ab + a
-    assert np.all(aba.integrate('type','eft')._sumw[()][1] == 2*sums)
-    assert aba.integrate('type','eft')._sumw2 is None
-    assert aba.integrate('type','non-eft')._sumw[()][1] == nevts
-    assert aba.integrate('type','non-eft')._sumw2 is None
+    assert np.all(aba.integrate("type", "eft_a").view(flow=False)[0] == 2 * sums)
+    assert np.all(aba.integrate("type", "eft_b").view(flow=False)[0] == nevts)
+
 
 def test_add_baa_noerrors():
     ba = b + a
     baa = ba + a
-    assert np.all(baa.integrate('type','eft')._sumw[()][1] == 2*sums)
-    assert baa.integrate('type','eft')._sumw2 is None
-    assert baa.integrate('type','non-eft')._sumw[()][1] == nevts
-    assert baa.integrate('type','non-eft')._sumw2 is None
+    assert np.all(baa.integrate("type", "eft_a").view(flow=False)[0] == 2 * sums)
+    assert np.all(baa.integrate("type", "eft_b").view(flow=False)[0] == nevts)
+
 
 def test_add_abb_noerrors():
     ab = a + b
     abb = ab + b
-    assert np.all(abb.integrate('type','eft')._sumw[()][1] == sums)
-    assert abb.integrate('type','eft')._sumw2 is None
-    assert abb.integrate('type','non-eft')._sumw[()][1] == 2*nevts
-    assert abb.integrate('type','non-eft')._sumw2 is None
+    assert np.all(abb.integrate("type", "eft_a").view(flow=False)[0] == sums)
+    assert np.all(abb.integrate("type", "eft_b").view(flow=False)[0] == 2 * nevts)
+
 
 def test_add_bab_noerrors():
     ba = b + a
     bab = ba + b
-    assert np.all(bab.integrate('type','eft')._sumw[()][1] == sums)
-    assert bab.integrate('type','eft')._sumw2 is None
-    assert bab.integrate('type','non-eft')._sumw[()][1] == 2*nevts
-    assert bab.integrate('type','non-eft')._sumw2 is None
+    assert np.all(bab.integrate("type", "eft_a").view(flow=False)[0] == sums)
+    assert np.all(bab.integrate("type", "eft_b").view(flow=False)[0] == 2 * nevts)
 
 
-a_w = HistEFT("Events", wc_names_lst,
-              hist.Cat("type", "type"),
-              hist.Bin("x",  "x", 1, 0, 1))
-# Just need another one where I won't fill the EFT coefficients
-b_w = a_w.copy(content=False)
+a_w = HistEFT(
+    hist.axis.StrCategory([], name="type", label="type", growth=True),
+    hist.axis.Regular(1, 0, 1, name="x", label="x"),
+    label="Events",
+    wc_names=wc_names_lst,
+)
+
+# Just need another one like the one above
+b_w = HistEFT(
+    hist.axis.StrCategory([], name="type", label="type", growth=True),
+    hist.axis.Regular(1, 0, 1, name="x", label="x"),
+    label="Events",
+    wc_names=wc_names_lst,
+)
 
 # Fill the EFT histogram
 weight_val = 0.9
-a_w.fill(type='eft', x=np.full(nevts,0.5), eft_coeff=eft_fit_coeffs, weight=np.full(nevts,weight_val))
-b_w.fill(type='non-eft', x=np.full(nevts,0.5), weight=np.full(nevts,weight_val))
+a_w.fill(
+    type="eft_a",
+    x=np.full(nevts, 0.5),
+    eft_coeff=eft_fit_coeffs,
+    weight=np.full(nevts, weight_val),
+)
+b_w.fill(
+    type="eft_b",
+    x=np.full(nevts, 0.5),
+    eft_coeff=eft_one_coeffs,
+    weight=np.full(nevts, weight_val),
+)
+
+
+def test_scale_a_weights():
+    ones = dict(zip(wc_names_lst, np.ones(wc_count)))
+    zeros = dict(zip(wc_names_lst, np.zeros(wc_count)))
+
+    intf = a_w.integrate("type", "eft_a").view(flow=True)[1]
+    assert intf[0] == 0
+    assert intf[-1] == 0
+    assert np.all(np.abs(intf[1:-1] - weight_val * sums) < 1e-10)  # drop under and overflow bins
+
+    integral = a_w.integrate("type", "eft_a").eval({})[()]
+    assert np.all(
+        np.abs(
+            a_w.integrate("type", "eft_a").eval(zeros)[()] == integral
+        )
+    )
+
+    assert np.any(
+        np.abs(
+            a_w.integrate("type", "eft_a").eval(ones)[()] != integral
+        )
+    )
+
+    a_w.integrate("type", "eft_a").eval(ones)[()].sum() - weight_val * sums.sum() < 1e-10
+
+
+def test_ac_deepcopy():
+    c_w = a_w.copy(deep=True)
+    assert np.all(
+        a_w.integrate("type", "eft_a").view(flow=False)[0] == c_w.integrate("type", "eft_a").view(flow=False)[0]
+    )
+    c_w.scale(1)
+    c_w.reset()
+    assert np.all(c_w.view(flow=False)[0] == 0)
+
+
+def test_group():
+    ab = a + b
+    c = ab.group("type", "all", {"efts": ["eft_a", "eft_b"]})
+    assert (
+        c.integrate("all", "efts").eval({})[()].sum()
+        == a.integrate("type", "eft_a").eval({})[()].sum()
+        + b.integrate("type", "eft_b").eval({})[()].sum()
+    )
+
 
 def test_add_ab_weights():
     ab = a_w + b_w
-    assert np.all(np.abs(ab.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
-    assert ab.integrate('type','eft')._sumw2[()] is None
-    assert abs(ab.integrate('type','non-eft')._sumw[()][1] - nevts*weight_val) < 1e-10
-    assert abs(ab.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*nevts) < 1e-10
+    assert np.all(
+        np.abs(ab.integrate("type", "eft_a").view(flow=False)[0] - weight_val * sums) < 1e-10
+    )
+    assert np.all(
+        np.abs(ab.integrate("type", "eft_b").view(flow=False)[0] - nevts * weight_val) < 1e-10
+    )
+
 
 def test_add_ba_weights():
     ba = b_w + a_w
-    assert np.all(np.abs(ba.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
-    assert ba.integrate('type','eft')._sumw2[()] is None
-    assert abs(ba.integrate('type','non-eft')._sumw[()][1] - nevts*weight_val) < 1e-10
-    assert abs(ba.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*nevts) < 1e-10
+    assert np.all(
+        np.abs(ba.integrate("type", "eft_a").view(flow=False)[0] - weight_val * sums) < 1e-10
+    )
+    assert np.all(
+        np.abs(ba.integrate("type", "eft_b").view(flow=False)[0] - nevts * weight_val) < 1e-10
+    )
+
 
 def test_add_aba_weights():
     ab = a_w + b_w
     aba = ab + a_w
-    assert np.all(np.abs(aba.integrate('type','eft')._sumw[()][1] - 2*weight_val*sums) < 1e-10)
-    assert aba.integrate('type','eft')._sumw2[()] is None
-    assert abs(aba.integrate('type','non-eft')._sumw[()][1] - nevts*weight_val) < 1e-10
-    assert abs(aba.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*nevts) < 1e-10
+    assert np.all(
+        np.abs(aba.integrate("type", "eft_a").view(flow=False)[0] - 2 * weight_val * sums) < 1e-10
+    )
+    assert np.all(
+        np.abs(aba.integrate("type", "eft_b").view(flow=False)[0] - nevts * weight_val) < 1e-10
+    )
+
 
 def test_add_baa_weights():
     ba = b_w + a_w
     baa = ba + a_w
-    assert np.all(np.abs(baa.integrate('type','eft')._sumw[()][1] - 2*weight_val*sums) < 1e-10)
-    assert baa.integrate('type','eft')._sumw2[()] is None
-    assert abs(baa.integrate('type','non-eft')._sumw[()][1] - nevts*weight_val) < 1e-10
-    assert abs(baa.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*nevts) < 1e-10
+    assert np.all(
+        np.abs(baa.integrate("type", "eft_a").view(flow=False)[0] - 2 * weight_val * sums) < 1e-10
+    )
+    assert np.all(
+        np.abs(baa.integrate("type", "eft_b").view(flow=False)[0] - nevts * weight_val) < 1e-10
+    )
+
 
 def test_add_abb_weights():
     ab = a_w + b_w
     abb = ab + b_w
-    assert np.all(np.abs(abb.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
-    assert abb.integrate('type','eft')._sumw2[()] is None
-    assert abs(abb.integrate('type','non-eft')._sumw[()][1] - 2*nevts*weight_val) < 1e-10
-    assert abs(abb.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*2*nevts) < 1e-10
+    assert np.all(
+        np.abs(abb.integrate("type", "eft_a").view(flow=False)[0] - weight_val * sums) < 1e-10
+    )
+    assert np.all(
+        np.abs(abb.integrate("type", "eft_b").view(flow=False)[0] - 2 * nevts * weight_val) < 1e-10
+    )
+
 
 def test_add_bab_weights():
     ba = b_w + a_w
     bab = ba + b_w
-    assert np.all(np.abs(bab.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
-    assert bab.integrate('type','eft')._sumw2[()] is None
-    assert abs(bab.integrate('type','non-eft')._sumw[()][1] - 2*nevts*weight_val) < 1e-10
-    assert abs(bab.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*2*nevts) < 1e-10
+    assert np.all(
+        np.abs(bab.integrate("type", "eft_a").view(flow=False)[0] - weight_val * sums) < 1e-10
+    )
+    assert np.all(
+        np.abs(bab.integrate("type", "eft_b").view(flow=False)[0] - 2 * nevts * weight_val) < 1e-10
+    )
 
-a_e = HistEFT("Events", wc_names_lst,
-              hist.Cat("type", "type"),
-              hist.Bin("x",  "x", 1, 0, 1))
-# Just need another one where I won't fill the EFT coefficients
-b_e = a_e.copy(content=False)
-
-#Now let's do the sum of the weights squared quartic too
-eft_w2_coeffs = efth.calc_w2_coeffs(eft_fit_coeffs)
-sums_w2 = np.sum(eft_w2_coeffs, axis=0)
-
-# Fill the EFT histogram
-a_e.fill(type='eft', x=np.full(nevts,0.5), eft_coeff=eft_fit_coeffs, eft_err_coeff=eft_w2_coeffs,
-         weight=np.full(nevts,weight_val))
-b_e.fill(type='non-eft', x=np.full(nevts,0.5), weight=np.full(nevts,weight_val))
-
-
-def test_add_ab_errors():
-    ab = a_e + b_e
-    assert np.all(np.abs(ab.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
-    assert np.all(np.abs(ab.integrate('type','eft')._sumw2[()][1] - (weight_val**2)*sums_w2) < 1e-10)
-    assert abs(ab.integrate('type','non-eft')._sumw[()][1] - nevts*weight_val) < 1e-10
-    assert abs(ab.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*nevts) < 1e-10
-
-def test_add_ba_errors():
-    ba = b_e + a_e
-    assert np.all(np.abs(ba.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
-    assert np.all(np.abs(ba.integrate('type','eft')._sumw2[()][1] - (weight_val**2)*sums_w2) < 1e-10)
-    assert abs(ba.integrate('type','non-eft')._sumw[()][1] - nevts*weight_val) < 1e-10
-    assert abs(ba.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*nevts) < 1e-10
-
-def test_add_aba_errors():
-    ab = a_e + b_e
-    aba = ab + a_e
-    assert np.all(np.abs(aba.integrate('type','eft')._sumw[()][1] - 2*weight_val*sums) < 1e-10)
-    assert np.all(np.abs(aba.integrate('type','eft')._sumw2[()][1] - 2*(weight_val**2)*sums_w2) < 1e-10)
-    assert abs(aba.integrate('type','non-eft')._sumw[()][1] - nevts*weight_val) < 1e-10
-    assert abs(aba.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*nevts) < 1e-10
-
-def test_add_baa_errors():
-    ba = b_e + a_e
-    baa = ba + a_e
-    assert np.all(np.abs(baa.integrate('type','eft')._sumw[()][1] - 2*weight_val*sums) < 1e-10)
-    assert np.all(np.abs(baa.integrate('type','eft')._sumw2[()][1] - 2*(weight_val**2)*sums_w2) < 1e-10)
-    assert abs(baa.integrate('type','non-eft')._sumw[()][1] - nevts*weight_val) < 1e-10
-    assert abs(baa.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*nevts) < 1e-10
-
-def test_add_abb_errors():
-    ab = a_e + b_e
-    abb = ab + b_e
-    assert np.all(np.abs(abb.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
-    assert np.all(np.abs(abb.integrate('type','eft')._sumw2[()][1] - (weight_val**2)*sums_w2) < 1e-10)
-    assert abs(abb.integrate('type','non-eft')._sumw[()][1] - 2*nevts*weight_val) < 1e-10
-    assert abs(abb.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*2*nevts) < 1e-10
-
-def test_add_bab_errors():
-    ba = b_e + a_e
-    bab = ba + b_e
-    assert np.all(np.abs(bab.integrate('type','eft')._sumw[()][1] - weight_val*sums) < 1e-10)
-    assert np.all(np.abs(bab.integrate('type','eft')._sumw2[()][1] - (weight_val**2)*sums_w2) < 1e-10)
-    assert abs(bab.integrate('type','non-eft')._sumw[()][1] - 2*nevts*weight_val) < 1e-10
-    assert abs(bab.integrate('type','non-eft')._sumw2[()][1] - (weight_val**2)*2*nevts) < 1e-10
 
 def test_split_by_terms():
-    integral = a.sum('type').values()[()].sum()
+    integral = a[{'type': sum}]
     c = a.split_by_terms(['x'], 'type')
-    assert integral == c.integrate('type', [k[0] for k in c.values() if 'eft' not in k[0]]).values()[()].sum()
+    assert integral == c.integrate('type', [k[0] for k in c.view(flow=True) if 'eft' not in k[0]]).view(flow=True)[()].sum()

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -14,7 +14,9 @@ def test_topcoffea():
         "-o",
         "output_check_yields",
         "-p",
-        "analysis/topEFT/histos/"
+        "analysis/topEFT/histos/",
+        "--prefix",
+        "http://www.crc.nd.edu/~kmohrman/files/root_files/for_ci/",
     ]
 
     # Run TopCoffea

--- a/tests/test_sparse_hist.py
+++ b/tests/test_sparse_hist.py
@@ -36,13 +36,16 @@ def test_simple_fill():
 
 def test_integrate():
     h = make_hist()
-    values = h.values()
+    r1 = h.integrate("channel", "ch0").values()
 
-    h.fill(process="ttH", channel="ch1", ptz=data_ptz)
+    h.fill(process="ttH", channel="ch1", ptz=data_ptz * 2)
 
-    h2 = h[{"channel": sum}]
+    r2 = h.integrate("channel", "ch0").values()
+    r3 = h.integrate("channel", "ch1").values()
 
-    assert ak.all(h2.values() == values[0, :] * 2)
+    assert ak.all(r1 == r2)
+    assert ak.any(r2 != r3)
+    assert ak.sum(h.values()) == ak.sum(r2 + r3)
 
 
 def test_slice():

--- a/tests/test_sparse_hist.py
+++ b/tests/test_sparse_hist.py
@@ -10,13 +10,9 @@ data_ptz = np.arange(0, 600, 600 / nbins)
 
 def make_hist():
     h = SparseHist(
-        categorical_axes=[
             hist.axis.StrCategory([], name="process", growth=True),
             hist.axis.StrCategory([], name="channel", growth=True),
-        ],
-        dense_axes=[
             hist.axis.Regular(nbins, 0, 600, name="ptz"),
-        ],
     )
     h.fill(process="ttH", channel="ch0", ptz=data_ptz)
 

--- a/tests/test_sparse_hist.py
+++ b/tests/test_sparse_hist.py
@@ -1,0 +1,111 @@
+import hist
+from topcoffea.modules.sparseHist import SparseHist
+
+import numpy as np
+import awkward as ak
+
+nbins = 12
+data_ptz = np.arange(0, 600, 600 / nbins)
+
+
+def make_hist():
+    h = SparseHist(
+        categorical_axes=[
+            hist.axis.StrCategory([], name="process", growth=True),
+            hist.axis.StrCategory([], name="channel", growth=True),
+        ],
+        dense_axes=[
+            hist.axis.Regular(nbins, 0, 600, name="ptz"),
+        ],
+    )
+    h.fill(process="ttH", channel="ch0", ptz=data_ptz)
+
+    return h
+
+
+def test_simple_fill():
+    h = make_hist()
+
+    # expect one count per bin
+    ones = np.ones((1, 1, nbins))
+    values = h.values(flow=False)
+    assert ak.all(values == ak.Array(ones))
+
+    # expect one count per bin, plus 0s for overflow
+    ones_with_flow = np.zeros((1, 1, nbins + 2))
+    ones_with_flow[0, 0, 1:-1] += ones[0, 0, :]
+    values = h.values(flow=True)
+    assert ak.all(values == ones_with_flow)
+
+
+def test_integrate():
+    h = make_hist()
+    values = h.values()
+
+    h.fill(process="ttH", channel="ch1", ptz=data_ptz)
+
+    h2 = h[{"channel": sum}]
+
+    assert ak.all(h2.values() == values[0, :] * 2)
+
+
+def test_slice():
+    h = make_hist()
+    h.fill(process="ttH", channel="ch1", ptz=data_ptz * 0.5)
+
+    h0 = h[{"channel": "ch0"}]
+    h1 = h[{"channel": "ch1"}]
+
+    assert ak.all(h.values()[:, 0, :] == h0.values())
+    assert ak.all(h.values()[:, 1, :] == h1.values())
+    assert ak.sum(h.values()) == ak.sum(h0.values()) + ak.sum(h1.values())
+
+
+def test_remove():
+    h = make_hist()
+    h.fill(process="ttH", channel="ch1", ptz=data_ptz * 0.5)
+
+    ha = h[{"channel": ["ch1"]}]
+
+    hr = h.remove("channel", ["ch0"])
+
+    assert ak.all(hr.values() == ha.values())
+
+
+def test_flow():
+    h = make_hist()
+
+    flowed = np.array([-10000, -10000, -10000, 10000, 10000, 10000, 10000])
+    h.fill(process="ttH", channel="ch0", ptz=flowed)
+
+    # expect one count per bin, plus the overflow
+    ones_with_flow = np.ones((1, 1, nbins + 2))
+    ones_with_flow[0, 0, 0] = np.count_nonzero(flowed < 0)
+    ones_with_flow[0, 0, -1] = np.count_nonzero(flowed > 1000)
+
+    values = h.values(flow=True)
+    assert(ak.all(values == ones_with_flow))
+
+
+def test_addition():
+    h = make_hist()
+
+    flowed = np.array([-10000, -10000, -10000, 10000, 10000, 10000, 10000])
+    h.fill(process="ttH", channel="ch0", ptz=flowed)
+
+    values = h.values(flow=True)
+    values2 = values * 2
+
+    h2 = h + h
+    assert(ak.all(h2.values(flow=True) == values2))
+
+
+def test_scale():
+    h = make_hist()
+    values = h.values(flow=True)
+
+    h *= 3
+    h12 = 4 * h
+    values12 = values * 12
+
+    assert(ak.all(h12.values(flow=True) == values12))

--- a/tests/test_yields.py
+++ b/tests/test_yields.py
@@ -14,7 +14,7 @@ def test_make_yields_after_processor():
     ]
 
     # Produce json
-    subprocess.run(args)
+    subprocess.run(args, check=True)
     assert (exists('analysis/topEFT/output_check_yields.json'))
 
 def test_compare_yields_after_processor():
@@ -30,5 +30,5 @@ def test_compare_yields_after_processor():
     ]
 
     # Run comparison
-    out = subprocess.run(args, stdout=True)
+    out = subprocess.run(args, check=True, stdout=True)
     assert (out.returncode == 0) # Returns 0 if all pass

--- a/topcoffea/modules/HistEFT.py
+++ b/topcoffea/modules/HistEFT.py
@@ -26,6 +26,8 @@ class HistEFT(coffea.hist.Hist):
 
     def __init__(self, label, wcnames, *axes, **kwargs):
         """ Initialize """
+        raise ValueError("No")
+
         if isinstance(wcnames, str) and ',' in wcnames: wcnames = wcnames.replace(' ', '').split(',')
         n = len(wcnames) if isinstance(wcnames, list) else wcnames
         self._wcnames = wcnames

--- a/topcoffea/modules/YieldTools.py
+++ b/topcoffea/modules/YieldTools.py
@@ -1,8 +1,7 @@
 import numpy as np
 import copy
 import coffea
-from coffea import hist
-from topcoffea.modules.HistEFT import HistEFT
+from topcoffea.modules.histEFT import HistEFT
 import topcoffea.modules.utils as utils
 
 class YieldTools():
@@ -324,7 +323,7 @@ class YieldTools():
     # Takes a hist, and retruns a list of the axis names
     def get_axis_list(self,histo):
         axis_lst = []
-        for axis in histo.axes():
+        for axis in histo.axes:
             axis_lst.append(axis.name)
         return axis_lst
 
@@ -344,7 +343,7 @@ class YieldTools():
     def get_cat_lables(self,hin_dict,axis,h_name=None):
 
         # If the hin is not a histo, then get one of the histos from inside of it
-        if not isinstance(hin_dict,HistEFT):
+        if not isinstance(hin_dict, HistEFT):
 
             # If no hist specified, just choose the first one
             if h_name is None:
@@ -364,12 +363,7 @@ class YieldTools():
             elif isinstance(hin_dict,dict):
                 hin_dict = hin_dict[h_name]
 
-        # Note: Use h.identifiers('axis') here, not axis.identifiers() (since according to Nick Smith "the axis may hold identifiers longer than the hist that uses it (hists can share axes)", but h.identifiers('axis') will get the ones actually contained in the histogram)
-        cats_lst = []
-        for identifier in hin_dict.identifiers(axis):
-            cats_lst.append(identifier.name)
-
-        return cats_lst
+        return list(hin_dict.axes[axis])
 
 
     # Remove the njet component of a category name, returns a new str
@@ -821,9 +815,9 @@ class YieldTools():
 
         # Print info about axes for one key
         print(f"\nPrinting info for key \"{h_name}\":")
-        for i in range(len(hin_dict[h_name].axes())):
-            print(f"\n    {i} Aaxis name:",hin_dict[h_name].axes()[i].name)
-            for cat in hin_dict[h_name].axes()[i].identifiers():
+        for i, axis in enumerate(hin_dict[h_name].axes):
+            print(f"\n    {i} Axis name:", axis.name)
+            for cat in axis:
                 print(f"\t{cat}")
 
 

--- a/topcoffea/modules/YieldTools.py
+++ b/topcoffea/modules/YieldTools.py
@@ -20,7 +20,7 @@ class YieldTools():
 
         self.DATA_MC_COLUMN_ORDER = ["tWZ", "VV", "VVV", "flips", "fakes", "conv", "bkg", "ttlnu", "ttll", "ttH", "tllq", "tHq", "tttt", "sig", "pred", "data", "pdiff"]
 
-        # A dictionary mapping names of samples in the samples axis to a short version of the name
+        # A dictionary mapping names of processes in the processes axis to a short version of the name
         self.PROC_MAP = {
 
             "ttlnu" : ["ttW_centralUL16APV"    ,"ttW_centralUL16"    ,"ttW_centralUL17" ,"ttW_centralUL18" , "ttlnuJet_privateUL18" , "ttlnuJet_privateUL17" , "ttlnuJet_privateUL16" , "ttlnuJet_privateUL16APV"],
@@ -217,7 +217,7 @@ class YieldTools():
     ######### Functions for getting process names from PROC_MAP #########
 
     # What this function does:
-    #   - Takes a full process name (i.e. the name of the category on the samples axis)
+    #   - Takes a full process name (i.e. the name of the category on the processes axis)
     #   - Then loops through PROC_MAP and returns the short (i.e. standard) version of the process name
     def get_short_name(self,long_name):
         ret_name = None
@@ -228,7 +228,7 @@ class YieldTools():
         return ret_name
 
     # What this function does:
-    #   - Takes a list of full process names (i.e. all of the categories on samples axis) and a key from PROC_MAP
+    #   - Takes a list of full process names (i.e. all of the categories on processes axis) and a key from PROC_MAP
     #   - Returns the long (i.e. the name of the category in the smples axis) corresponding to the short name
     def get_long_name(self,long_name_lst_in,short_name_in):
         ret_name = None
@@ -609,12 +609,12 @@ class YieldTools():
 
         # Find the yields
         yld_dict = {}
-        proc_lst = self.get_cat_lables(hin_dict,"sample")
+        proc_lst = self.get_cat_lables(hin_dict, "process")
         #if "flipsUL17" not in proc_lst: proc_lst = proc_lst + ["flipsUL16","flipsUL16APV","flipsUL17","flipsUL18"] # Very bad workaround for _many_ reasons.. leaving it in since it's useful for getting yields of the full pkl file (but we don't need it for e.g. the CI, so leave it commented), note this entire class is a mess and should be totally rewritten before the next analysis
         print("proc_lst",proc_lst)
         for proc in proc_lst:
             p = self.get_short_name(proc)
-            print("Name:",p,proc) # Print what name the sample has been matched to
+            print("Name:", p, proc) # Print what name the process has been matched to
 
         for proc in proc_lst:
             if year is not None:

--- a/topcoffea/modules/dataDrivenEstimation.py
+++ b/topcoffea/modules/dataDrivenEstimation.py
@@ -94,7 +94,7 @@ class DataDrivenProducer:
                         if newhist is None:
                             newhist = hFlips
                         else:
-                            newhist += hFlips
+                            newhist = newhist.union(hFlips, "process")
                     else:
                         # if we are in the nonprompt application region, we also integrate the application region axis
                         # and construct the new process 'nonprompt'
@@ -139,7 +139,7 @@ class DataDrivenProducer:
 
                         # now we actually make the subtraction
                         hPromptSub.scale(-1)
-                        hFakes += hPromptSub
+                        hFakes = hFakes.union(hPromptSub, "process")
 
                         # now adding them to the list of processes:
                         if newhist is None:

--- a/topcoffea/modules/dataDrivenEstimation.py
+++ b/topcoffea/modules/dataDrivenEstimation.py
@@ -49,9 +49,10 @@ class DataDrivenProducer:
                 if year not in ['16APV','16','17','18']:
                     raise RuntimeError(f"Sample {sample} does not match the naming convention, year \"{year}\" is unknown.")
 
-            prescale=histo.values().copy()
-            histo.scale( scale_dict, axis=('sample',))
-            postscale=histo.values()
+            # do these lines do anything? scale_dict is empty, and pre and postscale are never used.
+            # prescale = histo.eval(values=None).copy()
+            # histo.scale(scale_dict, axis=("process",))
+            # postscale = histo.eval(values=None)
 
             # now for each year we actually perform the subtraction and integrate out the application regions
             newhist=None

--- a/topcoffea/modules/dataDrivenEstimation.py
+++ b/topcoffea/modules/dataDrivenEstimation.py
@@ -79,7 +79,7 @@ class DataDrivenProducer:
                                 newNameDictData[nonPromptName].append(process)
                         hFlips = hAR.group(
                             "process",
-                            hist.StrCategory([], name="process", growth=True),
+                            "process",
                             newNameDictData,
                         )
 

--- a/topcoffea/modules/dataDrivenEstimation.py
+++ b/topcoffea/modules/dataDrivenEstimation.py
@@ -65,7 +65,7 @@ class DataDrivenProducer:
                     if newhist is None:
                         newhist = hAR
                     else:
-                        newhist = newhist.union(hAR, "process")
+                        newhist += hAR
                 else:
                     if "isAR_2lSS_OS" == ident:
                         # we are in the flips application region and theres no "prompt" subtraction, so we just have to rename data to flips, put it in the right axis and we are done
@@ -78,7 +78,6 @@ class DataDrivenProducer:
                             if self.dataName == sampleName:
                                 newNameDictData[nonPromptName].append(process)
                         hFlips = hAR.group(
-                            "process",
                             "process",
                             newNameDictData,
                         )
@@ -94,7 +93,7 @@ class DataDrivenProducer:
                         if newhist is None:
                             newhist = hFlips
                         else:
-                            newhist = newhist.union(hFlips, "process")
+                            newhist += hFlips
                     else:
                         # if we are in the nonprompt application region, we also integrate the application region axis
                         # and construct the new process 'nonprompt'
@@ -116,13 +115,11 @@ class DataDrivenProducer:
                                 )
                         hFakes = hAR.group(
                             "process",
-                            "process",
                             newNameDictData,
                         )
                         # now we take all the stuff that is not data in the AR to make the prompt
                         # subtraction and assign them to nonprompt.
                         hPromptSub = hAR.group(
-                            "process",
                             "process",
                             newNameDictNoData,
                         )
@@ -139,13 +136,13 @@ class DataDrivenProducer:
 
                         # now we actually make the subtraction
                         hPromptSub.scale(-1)
-                        hFakes = hFakes.union(hPromptSub, "process")
+                        hFakes += hPromptSub
 
                         # now adding them to the list of processes:
                         if newhist is None:
                             newhist = hFakes
                         else:
-                            newhist = newhist.union(hFakes, "process")
+                            newhist += hFakes
             self.outHist[key] = newhist
 
     def dumpToPickle(self):

--- a/topcoffea/modules/datacard_tools.py
+++ b/topcoffea/modules/datacard_tools.py
@@ -13,6 +13,7 @@ from coffea.hist import StringBin, Cat, Bin
 
 from topcoffea.modules.paths import topcoffea_path
 from topcoffea.modules.utils import regex_match
+from topcoffea.modules.topeft_axes import info as axes_info
 
 PRECISION = 6   # Decimal point precision in the text datacard output
 

--- a/topcoffea/modules/datacard_tools.py
+++ b/topcoffea/modules/datacard_tools.py
@@ -694,7 +694,7 @@ class DatacardMaker():
             it is excluded for that process and won't be included in the EFT decomposition
         """
         tic = time.time()
-        h = self.hists[km_dist].integrate("systematic",["nominal"])
+        h = self.hists[km_dist].integrate("systematic")
         if ch_lst:
             # Only select from a subset of channels
             if self.verbose:
@@ -730,7 +730,7 @@ class DatacardMaker():
         for p in procs:
             if not self.is_signal(p):
                 continue
-            p_hist = h.integrate("process", [p])
+            p_hist = h.integrate("process", p)
             for wc,idx_arr in wc_to_terms.items():
                 if len(self.coeffs) and not wc in self.coeffs:
                     continue
@@ -781,7 +781,7 @@ class DatacardMaker():
         outf_root_name = self.FNAME_TEMPLATE.format(cat=ch,kmvar=km_dist,ext="root")
 
         h = self.hists[km_dist]
-        ch_hist = h.integrate("channel", [ch])
+        ch_hist = h.integrate("channel", ch)
         data_obs = np.zeros((ch_hist.dense_axis.size,))
 
         print(f"Generating root file: {outf_root_name}")
@@ -792,7 +792,7 @@ class DatacardMaker():
         outf_root_name = os.path.join(self.out_dir,outf_root_name)
         with uproot.recreate(outf_root_name) as f:
             for p,wcs in selected_wcs.items():
-                proc_hist = ch_hist.integrate("process", [p])
+                proc_hist = ch_hist.integrate("process", p)
                 if self.verbose:
                     print(f"Decomposing {ch}-{p}")
                 decomposed_templates = self.decompose(proc_hist,wcs)

--- a/topcoffea/modules/datacard_tools.py
+++ b/topcoffea/modules/datacard_tools.py
@@ -468,7 +468,7 @@ class DatacardMaker():
                     x.replace("private", "").replace("central", "").replace("_4F", "")
                 )
                 grp_map[new_name] = x
-            h = h.group("process", "process", grp_map)
+            h = h.group("process", grp_map)
 
             h = self.group_processes(h)
             h = self.correlate_years(h)
@@ -594,7 +594,7 @@ class DatacardMaker():
         # Include back in everything that wasn't specified by the initial groupings
         for x in all_procs:
             grp_map[x] = [x]
-        h = h.group("process", "process", grp_map)
+        h = h.group("process", grp_map)
         return h
 
     # TODO: Can be a static member function
@@ -611,7 +611,7 @@ class DatacardMaker():
                 if p not in grp_map:
                     grp_map[p] = []
                 grp_map[p].append(x)
-            h = h.group("process", "process", grp_map)
+            h = h.group("process", grp_map)
             return h
         # This requires some fancy footwork to make work
         print("Correlating years")
@@ -676,7 +676,7 @@ class DatacardMaker():
             if p not in grp_map:
                 grp_map[p] = []
             grp_map[p].append(x)
-        h = h.group("process", "process", grp_map)
+        h = h.group("process", grp_map)
 
         # Remove the categories which were already correlated together so as to not double count
         if already_correlated:

--- a/topcoffea/modules/datacard_tools.py
+++ b/topcoffea/modules/datacard_tools.py
@@ -160,23 +160,10 @@ class DatacardMaker():
     }
 
     # Controls how we rebin the dense axis of the corresponding distribution
-    BINNING = {
-        # TODO: njets re-binning still not correctly implemented
-        "njets": {
-            "2l": [4,5,6,7],
-            "3l": [2,3,4,5],
-            "4l": [2,3,4],
-        },
-
-        "ptbl":    [0,100,200,400],
-        "ht":      [0,300,500,800],
-        "ljptsum": [0,400,600,1000],
-        "ptz":     [0,200,300,400,500],
-        "o0pt":    [0,100,200,400],
-        "bl0pt":   [0,100,200,400],
-        "l0pt":    [0,50,100,200],
-        "lj0pt":   [0,150,250,500]
-    }
+    BINNING = {}
+    for name, value in axes_info.items():
+        if "variable" in value:
+            BINNING[name] = value["variable"]
 
     YEARS = ["UL16","UL16APV","UL17","UL18"]
 

--- a/topcoffea/modules/datacard_tools.py
+++ b/topcoffea/modules/datacard_tools.py
@@ -781,8 +781,8 @@ class DatacardMaker():
         outf_root_name = self.FNAME_TEMPLATE.format(cat=ch,kmvar=km_dist,ext="root")
 
         h = self.hists[km_dist]
-        ch_hist = h.integrate("channel",[ch])
-        data_obs = np.zeros((2,ch_hist._dense_shape[0] - 1)) # '_dense_shape' includes the nanflow bin
+        ch_hist = h.integrate("channel", [ch])
+        data_obs = np.zeros((ch_hist.dense_axis.size,))
 
         print(f"Generating root file: {outf_root_name}")
         tic = time.time()
@@ -803,7 +803,7 @@ class DatacardMaker():
                     if self.use_real_data:
                         if len(data_sm) != 1:
                             raise RuntimeError("obs data has unexpected number of sparse bins")
-                        elif sum(data_obs[0]) != 0:
+                        elif sum(data_obs) != 0:
                             raise RuntimeError("filling obs data more than once!")
                         for sp_key,arr in data_sm.items():
                             data_obs += arr
@@ -903,7 +903,7 @@ class DatacardMaker():
             f.write(f"shapes *        * {os.path.split(outf_root_name)[1]} $PROCESS $PROCESS_$SYSTEMATIC\n")
             f.write(line_break)
             f.write(f"bin         {bin_str}\n")
-            f.write(f"observation {sum(data_obs[0]):.{PRECISION}f}\n")
+            f.write(f"observation {sum(data_obs):.{PRECISION}f}\n")
             f.write(line_break)
             f.write(line_break)
 

--- a/topcoffea/modules/datacard_tools.py
+++ b/topcoffea/modules/datacard_tools.py
@@ -9,18 +9,12 @@ import re
 import json
 import time
 
-from coffea.hist import StringBin, Cat, Bin
-
 from topcoffea.modules.paths import topcoffea_path
 from topcoffea.modules.utils import regex_match
 from topcoffea.modules.topeft_axes import info as axes_info
 
 PRECISION = 6   # Decimal point precision in the text datacard output
 
-def prune_axis(h,axis,to_keep):
-    """ Convenience method to remove all categories except for a selected subset."""
-    to_remove = [x.name for x in h.identifiers(axis) if x.name not in to_keep]
-    return h.remove(to_remove,axis)
 
 def to_hist(arr,name,zero_wgts=False):
     """
@@ -456,11 +450,11 @@ class DatacardMaker():
                         if self.verbose: print(f"Skipping (year): {x.name}")
                         to_remove.append(x.name)
                         continue
-            h = h.remove(to_remove,"sample")
+            h = h.remove("sample", to_remove)
 
             if not self.do_nuisance:
                 # Remove all shape systematics
-                h = prune_axis(h,"systematic",["nominal"])
+                h = h.prune("systematic", ["nominal"])
 
             if self.drop_syst:
                 to_drop = set()
@@ -732,7 +726,7 @@ class DatacardMaker():
             # Only select from a subset of channels
             if self.verbose:
                 print(f"Selecting WCs from subset of channels: {ch_lst}")
-            h = prune_axis(h,"channel",ch_lst)
+            h = h.prune("channel", ch_lst)
 
         procs = [x.name for x in h.identifiers("sample")]
         selected_wcs = {p: set() for p in procs}

--- a/topcoffea/modules/datacard_tools.py
+++ b/topcoffea/modules/datacard_tools.py
@@ -815,19 +815,17 @@ class DatacardMaker():
                         "rate": -1
                     }
                     # There should be only 1 sparse axis at this point, the systematics axis
-                    for sp_key,arr in v.items():
+                    for sp_key, arr in v.items():
                         if crop_negative_bins:
-                            negative_bin_mask = np.where( arr[0] < 0) # see where bins are negative
-                            arr[0][negative_bin_mask] = np.zeros_like( arr[0][negative_bin_mask] )  # set those to zero
-                            if arr[1] is not None:
-                                arr[1][negative_bin_mask] = np.zeros_like( arr[1][negative_bin_mask] )  # if there's a sumw2 defined, that one's set to zero as well. Otherwise we will get 0 +/- something, which is compatible with negative
+                            negative_bin_mask = np.where( arr < 0) # see where bins are negative
+                            arr[negative_bin_mask] = np.zeros_like( arr[negative_bin_mask] )  # set those to zero
 
                         syst = sp_key[0]
 
-                        sum_arr = sum(arr[0])
+                        sum_arr = sum(arr)
                         if syst == "nominal" and base == "sm":
                             if self.verbose:
-                                print(f"\t{proc_name:<12}: {sum_arr:.4f} {arr[0]}")
+                                print(f"\t{proc_name:<12}: {sum_arr:.4f} {arr}")
                             if not self.use_real_data:
                                 # Create asimov dataset
                                 data_obs += arr
@@ -872,8 +870,7 @@ class DatacardMaker():
                                 all_shapes.add(syst_base)
                                 text_card_info[proc_name]["shapes"].add(syst_base)
                             syst_width = max(len(syst),syst_width)
-                        zero_out_sumw2 = p != "fakes" # Zero out sumw2 for all proc but fakes, so that we only do auto stats for fakes
-                        f[hist_name] = to_hist(arr,hist_name,zero_wgts=zero_out_sumw2)
+                        f[hist_name] = to_hist(arr, hist_name)
 
                         num_h += 1
                     if km_dist == "njets":

--- a/topcoffea/modules/datacard_tools.py
+++ b/topcoffea/modules/datacard_tools.py
@@ -623,7 +623,7 @@ class DatacardMaker():
             unique_proc_years.add(yr)
 
         already_correlated = set()  # Keeps track of which systematics have already been correlated
-        for sp_key in h.sparse_keys():
+        for sp_key in h.categorical_keys(as_dict=True):
             proc = sp_key["process"]
             syst = sp_key["systematic"]
             proc_year = self.get_year(proc)
@@ -738,7 +738,7 @@ class DatacardMaker():
                     continue
                 if wc == "ctlTi" and p == "tttt":
                     continue
-                for sparse_key in p_hist.sparse_keys():
+                for sparse_key in p_hist.categorical_keys():
                     # Drop underflow
                     sl_arr = p_hist[sparse_key].values(flow=True)[..., 1:, :]
                     # Here we replace any SM terms that are too small with a large dummy value
@@ -782,7 +782,7 @@ class DatacardMaker():
 
         h = self.hists[km_dist]
         ch_hist = h.integrate("channel", ch)
-        data_obs = np.zeros((ch_hist.dense_axis.size,))
+        data_obs = np.zeros((ch_hist.dense_axis.extent,))
 
         print(f"Generating root file: {outf_root_name}")
         tic = time.time()
@@ -1052,8 +1052,7 @@ class DatacardMaker():
 
             r[lin_name] = tmp_lin_1
             r[quad_name] = {}
-            for sp_key in h.sparse_keys():
-                tup = tuple(sp_key.values())
+            for tup in h.categorical_keys():
                 r[quad_name][tup] = np.zeros((2,))
                 for i in range(2):
                     r[quad_name][tup][i] = 0.5 * (

--- a/topcoffea/modules/eft_helper.py
+++ b/topcoffea/modules/eft_helper.py
@@ -33,7 +33,6 @@ def calc_eft_weights(q_coeffs, wc_values):
     for i in range(len(wcs)):
         for j in range(i + 1):
             out += q_coeffs[..., index] * wcs[i] * wcs[j]
-            print(out, q_coeffs[..., index], wcs[i], wcs[j])
             index += 1
     return out
 

--- a/topcoffea/modules/eft_helper.py
+++ b/topcoffea/modules/eft_helper.py
@@ -29,10 +29,11 @@ def calc_eft_weights(q_coeffs, wc_values):
     out = np.zeros_like(q_coeffs[..., 0])
 
     # Now loop over the terms and multiply them out
-    index = 0
+    index = 1  # start at second column, as first is 0s from boost_histogram underflow (real underflow is row 0)
     for i in range(len(wcs)):
         for j in range(i + 1):
             out += q_coeffs[..., index] * wcs[i] * wcs[j]
+            print(out, q_coeffs[..., index], wcs[i], wcs[j])
             index += 1
     return out
 

--- a/topcoffea/modules/eft_helper.py
+++ b/topcoffea/modules/eft_helper.py
@@ -26,13 +26,13 @@ def calc_eft_weights(q_coeffs, wc_values):
     # Initialize the array that will return the coefficients.  It
     # should be the same shape as q_coeffs except missing the last
     # dimension.
-    out = np.zeros_like(q_coeffs[..., 0].view(flow=True))
+    out = np.zeros_like(q_coeffs[..., 0])
 
     # Now loop over the terms and multiply them out
     index = 0
     for i in range(len(wcs)):
         for j in range(i + 1):
-            out += q_coeffs[..., index].view(flow=True) * wcs[i] * wcs[j]
+            out += q_coeffs[..., index] * wcs[i] * wcs[j]
             index += 1
     return out
 

--- a/topcoffea/modules/eft_helper.py
+++ b/topcoffea/modules/eft_helper.py
@@ -21,21 +21,19 @@ def calc_eft_weights(q_coeffs, wc_values):
     """
 
     # Prepend "1" to the start of the WC array to account for constant and linear terms
-    wcs = np.hstack((np.ones(1),wc_values))
+    wcs = np.hstack((np.ones(1), wc_values))
 
     # Initialize the array that will return the coefficients.  It
     # should be the same shape as q_coeffs except missing the last
-    # dimension
-    out = np.zeros_like(q_coeffs[...,0])
+    # dimension.
+    out = np.zeros_like(q_coeffs[..., 0].view(flow=True))
 
     # Now loop over the terms and multiply them out
     index = 0
     for i in range(len(wcs)):
-        for j in range(i+1):
-            out += q_coeffs[...,index]*wcs[i]*wcs[j]
-            index+=1
-
-    # Done, return the result
+        for j in range(i + 1):
+            out += q_coeffs[..., index].view(flow=True) * wcs[i] * wcs[j]
+            index += 1
     return out
 
 @numba.njit

--- a/topcoffea/modules/eft_helper.py
+++ b/topcoffea/modules/eft_helper.py
@@ -6,8 +6,8 @@ import numba
 from numba.typed import List
 import math
 
-@numba.njit
-def calc_eft_weights(q_coeffs,wc_values):
+
+def calc_eft_weights(q_coeffs, wc_values):
     """Calculate the weights for a specific set of WC values.
 
     Args:

--- a/topcoffea/modules/histEFT.py
+++ b/topcoffea/modules/histEFT.py
@@ -55,7 +55,7 @@ class HistEFT(SparseHist, family=_family):
         ],
     )
 
-    # eval at 0, returns a dictionary from categorical axes bins to array, same as justsm,
+    # eval at 0, returns a dictionary from categorical axes bins to array, same as just sm,
     # {('ttH',): array([-100. ,   3.6,    1.4,    1.5,  600. ])}
     h.eval({})
     h.eval({"ctG": 0})     # same thing
@@ -300,9 +300,9 @@ class HistEFT(SparseHist, family=_family):
             **self._init_args_base,
         )
 
-        sparse_names = list(axis.name for axis in self.categorical_axes())
-        for sp_vals, arrs in evals.items():
-            sp_key = dict(zip(sparse_names, sp_vals))
+        sparse_names = self.categorical_axes.name
+        for sp_val, arrs in evals.items():
+            sp_key = dict(zip(sparse_names, sp_val))
             nhist[sp_key] = arrs
         return nhist
 

--- a/topcoffea/modules/histEFT.py
+++ b/topcoffea/modules/histEFT.py
@@ -1,0 +1,452 @@
+#! /usr/bin/env python
+
+import hist
+import boost_histogram as bh
+import numpy as np
+
+from itertools import product, chain
+
+from typing import Any, List, Mapping, Union
+
+import topcoffea.modules.eft_helper as efth
+
+try:
+    from numpy.typing import ArrayLike, Self
+except ImportError:
+    ArrayLike = Any
+    Number = Any
+    Self = Any
+
+
+_family = hist
+
+
+class HistEFT(hist.NamedHist, family=_family):
+    """ Histogram specialized to hold Wilson Coefficients.
+    Example:
+    ```
+    h = HistEFT(
+        hist.axis.StrCategory(["ttH"], name="process", growth=True),
+        hist.axis.Regular(
+            name="ht",
+            label="ht [GeV]",
+            bins=3,
+            start=0,
+            stop=30,
+            flow=True,
+        ),
+        wc_names=["ctG"],
+        label="Events",
+    )
+
+    h.fill(
+        process="ttH",
+        ht=np.array([1, 1, 2, 15, 25, 100, -100]),
+        # per row, quadratic coefficient values associated with one event.
+        eft_coeff=[
+            [1.1, 2.1, 3.1],     # to (ttH, 1j) bins (one bin per coefficient)
+            [1.2, 2.2, 3.2],     # to (ttH, 1j) bins
+            [1.3, 2.3, 3.3],     # to (ttH, 2j) bins
+            [1.4, 2.4, 3.4],     # to (ttH, 15j) bins
+            [1.5, 2.5, 3.5],     # to (ttH, 25j) bins
+            [100, 200, 300],     # to (ttH, overflow given 100 >= stop) bins
+            [-100, -200, -300],  # to (ttH, underflow given -100 < start) bins
+        ],
+    )
+
+    # eval at 0, returns a dictionary from categorical axes bins to array, same as justsm,
+    # {('ttH',): array([-100. ,   3.6,    1.4,    1.5,  600. ])}
+    h.eval({})
+    h.eval({"ctG": 0})     # same thing
+    h.eval(np.zeros((1,))  # same thing
+
+    # eval at 1, same as adding all bins together per bins of dense axis.
+    # {('ttH',): array([-600. ,   19.8,    7.2,    7.5,  600. ])}
+    h.eval({"ctG": 1})     # same thing
+    h.eval(np.ones((1,))  # same thing
+
+    # instead of h.eval(...), h.as_hist(...) may be used to create a standard hist.Hist with the
+    # result of the evaluation:
+    hn = h.as_hist({"ctG": 0.02})
+    hn.plot1d()
+    ```
+    """
+
+    def __init__(
+        self,
+        *args,
+        wc_names: Union[List[str], None] = None,
+        **kwargs,
+    ) -> None:
+        """ HistEFT initialization is similar to hist.Hist, with the following restrictions:
+        - All axes should have a name.
+        - Exactly one axis can be dense (i.e. hist.axis.Regular, hist.axis.Variable, or his.axis.Integer)
+        - The dense axis should be the last specified in the list of arguments.
+        - Categorical axes should be specified with growth=True.
+        """
+
+        if not wc_names:
+            wc_names = []
+
+        n = len(wc_names)
+        self._wc_names = {n: i for i, n in enumerate(wc_names)}
+        self._wc_count = n
+        self._quad_count = efth.n_quad_terms(n)
+
+        # a little ugly, but we need to keep these arguments in case we need to create a new histogram with group(...)
+        self._init_args_base = dict(kwargs)
+        self._init_args_eft = {"wc_names": wc_names}
+
+        self._needs_rebinning = kwargs.pop("rebin", False)
+        if self._needs_rebinning:
+            raise ValueError("Do not know how to rebin yet...")
+
+        kwargs.setdefault("storage", "Double")
+        if kwargs["storage"] != "Double":
+            raise ValueError("only 'Double' storage is supported")
+
+        self._dense_axis = args[-1]
+        if not isinstance(
+            self._dense_axis, (bh.axis.Regular, bh.axis.Variable, bh.axis.Integer)
+        ):
+            raise ValueError("dense axis should be the last specified")
+
+        reserved_names = ["quadratic_term", "sample", "weight", "thread"]
+        if any([axis.name in reserved_names for axis in args]):
+            raise ValueError(
+                f"No axis may have one of the following names: {','.join(reserved_names)}"
+            )
+
+        self._coeff_axis = hist.axis.Integer(
+            start=0, stop=self._quad_count, name="quadratic_term"
+        )
+        super().__init__(*args, self._coeff_axis, **kwargs)
+
+        if len(list(self.sparse_axes)) != len(self.axes) - 2:
+            raise ValueError("exactly one dense axis should be specified.")
+
+    def wc_names(self):
+        return list(self._wc_names)
+
+    def index_of_wc(self, wc: str):
+        return self._wc_names[wc]
+
+    def quadratic_term_index(self, *wcs: List[str]):
+        """Given the name of two coefficients, it returns the index
+        of the corresponding quadratic coefficient. E.g., if the
+        histogram was defined with wc_names=["ctG"]:
+
+        h.quadratic_term_index("sm", "sm")   -> 0
+        h.quadratic_term_index("sm", "ctG")  -> 1
+        h.quadratic_term_index("ctG", "ctG") -> 2
+        """
+
+        def str_to_index(s):
+            if s == "sm":
+                return 0
+            else:
+                return self.index_of_wc(s) + 1
+
+        if len(wcs) != 2:
+            raise ValueError("List of coefficient names should have length 2")
+
+        wc1, wc2 = map(str_to_index, wcs)
+        if wc1 < wc2:
+            wc1, wc2 = wc2, wc1
+
+        return int((((wc1 + 1) * wc1) / 2) + wc2)
+
+    def should_rebin(self):
+        return self._needs_rebinning
+
+    @property
+    def sparse_axes(self):
+        return filter(
+            lambda axis: isinstance(axis, (bh.axis.StrCategory, bh.axis.IntCategory)),
+            self.axes,
+        )
+
+    @property
+    def dense_axis(self):
+        return self._dense_axis
+
+    def _fill_flatten(self, a, n_events):
+        # manipulate input arrays into flat arrays. broadcast_to and ravel used so that arrays are not duplicated in memory
+        a = np.asarray(a)
+        if a.ndim > 2 or (a.ndim == 2 and (a.shape != (n_events, 1))):
+            raise ValueError(
+                "Incompatible dimensions between data and Wilson coefficients."
+            )
+
+        if a.ndim > 1:
+            a = a.ravel()
+
+        # turns [e0, e1, ...] into [[e0, e0, ...],
+        #                           [e1, e1, ...],
+        #                            [...       ]]
+        # and then into       [e0, e0, ..., e1, e1, ..., e2, e2, ...]
+        # each value repeated the number of quadratic coefficients.
+        return np.broadcast_to(a, (self._quad_count, n_events)).T.ravel()
+
+    def _fill_indices(self, n_events):
+        # turns [0, 1, 2, ..., num of quadratic coeffs - 1]
+        # into:
+        # [0, 1, 2, ..., 0, 1, 2 ...,]
+        # repeated n_events times.
+        return np.broadcast_to(
+            np.ogrid[0 : self._quad_count], (n_events, self._quad_count)
+        ).ravel()
+
+    def fill(
+        self,
+        eft_coeff: ArrayLike = None,  # [num of events x (num of wc coeffs + 1)]
+        **values,
+    ) -> Self:
+        """
+        Insert data into the histogram using names and indices, return
+        a HistEFT object.
+
+        arg:       [ e0, e1 ]         each entry is the value for one event.
+        weight:    [ w0, w1 ]         weight per event
+        eft_coeff: [[c00, c01, c02]   each row is the coefficient values for one event,
+                    [c10, c11, c12]]  cij is the value of jth coefficient for the ith event.
+                                      ei, wi, and ci* go together.
+        """
+
+        n_events = len(values[self.dense_axis.name])
+
+        if self._quad_count < 2 and not eft_coeff:
+            # if just doing sm and not given eft_coeff 'weights', assume they are one.
+            eft_coeff = np.broadcast_to(1, (n_events, 1))
+
+        eft_coeff = np.asarray(eft_coeff)
+        values_b = {}
+        for n, a in values.items():
+            # turn into [e0, e0, ..., e1, e1, ..., e2, e2, ...]
+            values_b[n] = self._fill_flatten(a, n_events)
+
+        # turn into: [c00, c01, c02, ..., c10, c11, c12, ...]
+        eft_coeff = eft_coeff.ravel()
+
+        # index for coefficient axes.
+        # [ 0, 1, 2, ..., 0, 1, 2, ...]
+        indices = self._fill_indices(n_events)
+
+        weight = values_b.pop("weight", None)
+        if weight is not None:
+            eft_coeff = eft_coeff * weight
+
+        # fills:
+        # [e0,      e0,      e0    ..., e1,     e1,     e1,     ...]
+        # [ 0,      1,       2,    ..., 0,      1,      2,      ...]
+        # [c00*w0, c01*w0, c02*w0, ..., c10*w1, c11*w1, c12*w1, ...]
+        super().fill(quadratic_term=indices, **values_b, weight=eft_coeff)
+
+    def sparse_keys(self):
+        # axis give iterators on the name of their buckets, so we simply feed them to the itertools product.
+        sparse_names = list(axis.name for axis in self.sparse_axes)
+        for val in product(*self.sparse_axes):
+            yield dict(zip(sparse_names, val))
+
+    def _wc_for_eval(self, values):
+        """Set the WC values used to evaluate the bin contents of this histogram
+        where the WCs are specified as keyword arguments.  Any WCs not listed are set to zero.
+        """
+
+        if not values:
+            return np.zeros(self._wc_count)
+
+        result = values
+        if isinstance(values, Mapping):
+            result = np.zeros(self._wc_count)
+            for wc, val in values.items():
+                try:
+                    index = self._wc_names[wc]
+                    result[index] = val
+                except KeyError:
+                    msg = f'This HistEFT does not know about the "{wc}" Wilson coefficient. Known coefficients: {list(self._wc_names.keys())}'
+                    raise LookupError(msg)
+
+        return np.asarray(result)
+
+    def eval(self, values):
+        """Extract the sum of weights arrays from this histogram
+        Parameters
+        ----------
+        values: ArrayLike or Mapping or None
+            The WC values used to evaluate the bin contents of this histogram. Either an array with the values, or a dictionary. If None, use an array of zeros.
+        """
+
+        values = self._wc_for_eval(values)
+        out = {}
+        for sparse_key in self.sparse_keys():
+            out[tuple(sparse_key.values())] = efth.calc_eft_weights(
+                self[sparse_key], values
+            )
+        return out
+
+    def as_hist(self, values):
+        """Construct a regular histogram evaluated at values.
+        (Like self.eval(...) but result is a histogram.)
+        Parameters
+        ----------
+        values: ArrayLike or Mapping or None
+            The WC values used to evaluate the bin contents of this histogram. Either an array with the values, or a dictionary. If None, use an array of zeros.
+        overflow: bool
+            Whether to include under and overflow bins.
+        """
+        evals = self.eval(values=values)
+        nhist = hist.Hist(
+            *[axis for axis in self.axes if axis != self._coeff_axis],
+            **self._init_args_base,
+        )
+
+        sparse_names = list(axis.name for axis in self.sparse_axes)
+        for sp_vals, arrs in evals.items():
+            sp_key = dict(zip(sparse_names, sp_vals))
+            nhist[sp_key] = arrs
+        return nhist
+
+    def group(self: Self, old_name: str, new_name: str, groups: dict[str, list[str]]):
+        """ Generate a new HistEFT where bins of axis named old_name are merged
+        according to the groups mapping. The axis of the resuling histogram is
+        named new_name.
+
+        WARNING: Given restrictions on boost-histogram, it is sometimes not possible to use
+        arithmetic operations directly on the resulting histograms, as they differ
+        in the name and order of the bins. If you need to add histograms, resulting
+        from this mehtod, use HistEFT.union(...)
+        """
+        if old_name != new_name:
+            for ax in self.axes:
+                if new_name == ax.name:
+                    raise ValueError("Name of new axis is already in use")
+
+        old_axis = self.axes[old_name]
+        new_axis = hist.axis.StrCategory(
+            groups.keys(), name=new_name, label=old_axis.label, growth=True
+        )
+
+        new_axes = []
+        for axis in self.axes:
+            if axis.name == old_name:
+                new_axes.append(new_axis)
+            elif axis != self._coeff_axis:
+                new_axes.append(axis)
+
+        hnew = HistEFT(
+            *new_axes,
+            **self._init_args_base,
+            **self._init_args_eft,
+        )
+
+        hnew._coeff_axis.label = self._coeff_axis.label
+
+        for join, splits in groups.items():
+            if isinstance(splits, str):
+                splits = [splits]
+            joined = sum(self[{old_name: split}] for split in splits)
+            hnew[{new_name: join}] = joined.view(flow=True)
+        return hnew
+
+    def remove(self, axis_name, bins):
+        """Remove bins from a sparse axis
+
+        Parameters
+        ----------
+            bins : iterable
+                A list of bin identifiers to remove
+            axis : str
+                Sparse axis name
+
+        Returns a *copy* of the histogram with specified bins removed, not an in-place operation
+        """
+        axis = self.axes[axis_name]
+        if not isinstance(axis, (bh.axis.StrCategory, bh.axis.IntCategory)):
+            raise NotImplementedError(
+                "HistEFT.remove() only supports removing items from a sparse axis."
+            )
+        bins = [axis.index(binid) for binid in bins]
+        keep = [binid for binid in axis if binid not in bins]
+        full_slice = tuple(slice(None) if ax != axis else keep for ax in self.axes)
+        return self[full_slice]
+
+    def prune(self, axis, to_keep):
+        """Convenience method to remove all categories except for a selected subset.
+        Returns a *copy* of the histogram with specified bins removed, not an in-place operation
+        """
+        to_remove = [x for x in self.axes[axis] if x not in to_keep]
+        return self.remove(axis, to_remove)
+
+    def union(self: Self, other: Self, axis_name: str):
+        """Creates a new histogram from the union with another histogram
+        adding slices from along axis_name.
+        It is like self + other, but allows bins in the axis with axis_name
+        across the input histograms to be distinct. The rest of the axes
+        are enforced to be compatible across histograms."""
+
+        s_axis = self.axes[axis_name]
+        o_axis = other.axes[axis_name]
+
+        n_axis = hist.axis.StrCategory(
+            chain(s_axis, o_axis), name=axis_name, label=s_axis.label, growth=True
+        )
+
+        new_axes = []
+        for axis in self.axes:
+            if axis == s_axis:
+                new_axes.append(n_axis)
+            elif axis != self._coeff_axis:
+                new_axes.append(axis)
+
+        if self.shape != other.shape:
+            ValueError(
+                "Cannot use union on these histograms as they have different dimensions."
+            )
+
+        for s, o in zip(self.axes, other.axes):
+            if s == s_axis:
+                continue
+            if s.name != o.name or list(s) != list(o):
+                ValueError(
+                    "Cannot use union on these histograms as axis are not mergable."
+                )
+
+        hnew = HistEFT(
+            *new_axes,
+            **self._init_args_base,
+            **self._init_args_eft,
+        )
+
+        s_bins = set(s_axis)
+        o_bins = set(o_axis)
+
+        for bin in s_bins.union(o_bins):
+            hs = []
+            if bin in s_bins:
+                hs.append(self[{axis_name: bin}].view(flow=True))
+            if bin in o_bins:
+                hs.append(other[{axis_name: bin}].view(flow=True))
+            hnew[{axis_name: bin}] = sum(hs)
+
+        return hnew
+
+    # convenience methods for compatibility methods for coffea.hist
+    def integrate(self, name: str, value: Union[Any, None] = None):
+        if value is None:
+            value = sum
+        return self[{name: value}]
+
+    def scale(self, factor: float):
+        self *= factor
+        return self
+
+    def empty(self):
+        return np.all(self.counts() == 0)
+
+    # compatibility methods for old coffea
+    # all of these are deprecated
+    def identity(self):
+        h = self.copy(deep=False)
+        h.reset()
+        return h

--- a/topcoffea/modules/histEFT.py
+++ b/topcoffea/modules/histEFT.py
@@ -289,6 +289,16 @@ class HistEFT(hist.NamedHist, family=_family):
             out[tuple(sparse_key.values())] = efth.calc_eft_weights(
                 self[sparse_key], values
             )
+
+        import traceback
+        with open("/tmp/new_hist.txt", "a") as f:
+            traceback.print_stack(limit=10, file=f)
+            f.write(str(values))
+            f.write("\n")
+            for k in sorted(out.keys()):
+                f.write(str(k))
+                f.write(str(out[k]))
+                f.write("\n")
         return out
 
     def as_hist(self, values):

--- a/topcoffea/modules/histEFT.py
+++ b/topcoffea/modules/histEFT.py
@@ -433,6 +433,9 @@ class HistEFT(hist.NamedHist, family=_family):
 
     # convenience methods for compatibility methods for coffea.hist
     def integrate(self, name: str, value: Union[Any, None] = None):
+        if isinstance(value, List):
+            raise ValueError("A list is no longer a valid argument for integrate.")
+
         if value is None:
             value = sum
         return self[{name: value}]

--- a/topcoffea/modules/histEFT.py
+++ b/topcoffea/modules/histEFT.py
@@ -206,18 +206,24 @@ class HistEFT(hist.NamedHist, family=_family):
         Insert data into the histogram using names and indices, return
         a HistEFT object.
 
-        arg:       [ e0, e1 ]         each entry is the value for one event.
-        weight:    [ w0, w1 ]         weight per event
-        eft_coeff: [[c00, c01, c02]   each row is the coefficient values for one event,
-                    [c10, c11, c12]]  cij is the value of jth coefficient for the ith event.
-                                      ei, wi, and ci* go together.
+        arg:       [ e0, e1, ... ]         each entry is the value for one event.
+        weight:    [ w0, w1, ... ]         weight per event
+        eft_coeff: [[c00, c01, c02, ...]   each row is the coefficient values for one event,
+                    [c10, c11, c12, ...]
+                    ...                 ]  cij is the value of jth coefficient for the ith event.
+                                           ei, wi, and ci* go together.
+
+        If eft_coeff is not given, then it is assumed to be [[1, 0, 0, ...], [1, 0, 0, ...], ...]
         """
 
         n_events = len(values[self.dense_axis.name])
 
-        if self._quad_count < 2 and not eft_coeff:
-            # if just doing sm and not given eft_coeff 'weights', assume they are one.
-            eft_coeff = np.broadcast_to(1, (n_events, 1))
+        if eft_coeff is None:
+            # if eft_coeff not given, assume values only for sm
+            eft_coeff = np.broadcast_to(
+                np.concatenate((np.ones((1,)), np.zeros((self._quad_count - 1,)))),
+                (n_events, self._quad_count),
+            )
 
         eft_coeff = np.asarray(eft_coeff)
         values_b = {}

--- a/topcoffea/modules/histEFT.py
+++ b/topcoffea/modules/histEFT.py
@@ -306,43 +306,6 @@ class HistEFT(SparseHist, family=_family):
             nhist[sp_key] = arrs
         return nhist
 
-    def group(self, old_name: str, new_name: str, groups: Dict[str, List[str]]):
-        """ Generate a new HistEFT where bins of axis named old_name are merged
-        according to the groups mapping. The axis of the resuling histogram is
-        named new_name.
-        """
-        if old_name != new_name:
-            for ax in self.axes:
-                if new_name == ax.name:
-                    raise ValueError("Name of new axis is already in use")
-
-        old_axis = self.axes[old_name]
-        new_axis = hist.axis.StrCategory(
-            groups.keys(), name=new_name, label=old_axis.label, growth=True
-        )
-
-        new_axes = []
-        for axis in self.axes:
-            if axis.name == old_name:
-                new_axes.append(new_axis)
-            elif axis != self._coeff_axis:
-                new_axes.append(axis)
-
-        hnew = type(self)(
-            *new_axes,
-            **self._init_args_base,
-            **self._init_args_eft,
-        )
-
-        hnew._coeff_axis.label = self._coeff_axis.label
-
-        for join, splits in groups.items():
-            if isinstance(splits, str):
-                splits = [splits]
-            joined = sum(self[{old_name: split}] for split in splits)
-            hnew[{new_name: join}] = joined.view(flow=True)
-        return hnew
-
     def scale(self, factor: float):
         self *= factor
         return self

--- a/topcoffea/modules/histEFT.py
+++ b/topcoffea/modules/histEFT.py
@@ -306,16 +306,19 @@ class HistEFT(SparseHist, family=_family):
             nhist[sp_key] = arrs
         return nhist
 
-    def scale(self, factor: float):
-        self *= factor
-        return self
+    def __reduce__(self):
+        return (
+            type(self)._read_from_reduce,
+            (
+                list(self.categorical_axes),
+                [self.dense_axis],
+                [self._init_args_base, self._init_args_eft],
+                self._dense_hists,
+            ),
+        )
 
-    def empty(self):
-        return np.all(self.values(flow=True) == 0)
-
-    # compatibility methods for old coffea
-    # all of these are deprecated
-    def identity(self):
-        h = self.copy(deep=False)
-        h.reset()
-        return h
+    @classmethod
+    def _read_from_reduce(cls, cat_axes, dense_axes, init_args, dense_hists):
+        kwargs, eft = init_args
+        kwargs.update(eft)
+        return super()._read_from_reduce(cat_axes, dense_axes, kwargs, dense_hists)

--- a/topcoffea/modules/histEFT.py
+++ b/topcoffea/modules/histEFT.py
@@ -238,6 +238,7 @@ class HistEFT(SparseHist, family=_family):
 
         weight = values.pop("weight", None)
         if weight is not None:
+            weight = self._fill_flatten(weight, n_events)
             eft_coeff = eft_coeff * weight
 
         # fills:

--- a/topcoffea/modules/histEFT.py
+++ b/topcoffea/modules/histEFT.py
@@ -342,15 +342,6 @@ class HistEFT(SparseHist, family=_family):
             hnew[{new_name: join}] = joined.view(flow=True)
         return hnew
 
-    # convenience methods for compatibility methods for coffea.hist
-    def integrate(self, name: str, value: Union[Any, None] = None):
-        if isinstance(value, List):
-            raise ValueError("A list is no longer a valid argument for integrate.")
-
-        if value is None:
-            value = sum
-        return self[{name: value}]
-
     def scale(self, factor: float):
         self *= factor
         return self

--- a/topcoffea/modules/histEFT.py
+++ b/topcoffea/modules/histEFT.py
@@ -127,8 +127,10 @@ class HistEFT(SparseHist, family=_family):
                 f"No axis may have one of the following names: {','.join(reserved_names)}"
             )
 
-        print(args)
         super().__init__(*args, self._coeff_axis, **kwargs)
+
+    def from_categorical_axes_like(self, *axes):
+        return type(self)(*axes, self._dense_axis, **self._init_args_base, **self._init_args_eft)
 
     def wc_names(self):
         return list(self._wc_names)
@@ -276,12 +278,10 @@ class HistEFT(SparseHist, family=_family):
         """
 
         values = self._wc_for_eval(values)
+
         out = {}
-        for sparse_key in self.categorical_keys():
-            print(self[sparse_key])
-            out[sparse_key] = efth.calc_eft_weights(
-                self[sparse_key], values
-            )
+        for sparse_key, hvs in self.view(flow=True, as_dict=True).items():
+            out[sparse_key] = efth.calc_eft_weights(hvs, values)
         return out
 
     def as_hist(self, values):

--- a/topcoffea/modules/histEFT.py
+++ b/topcoffea/modules/histEFT.py
@@ -253,7 +253,7 @@ class HistEFT(SparseHist, family=_family):
         """Set the WC values used to evaluate the bin contents of this histogram
         where the WCs are specified as keyword arguments.  Any WCs not listed are set to zero.
         """
-        if not values:
+        if values is None:
             return np.zeros(self._wc_count)
 
         result = values

--- a/topcoffea/modules/sparseHist.py
+++ b/topcoffea/modules/sparseHist.py
@@ -255,8 +255,10 @@ class SparseHist(hist.Hist, family=hist):
             return self._from_hists(filtered, new_cats, collapsed)
 
     def _ak_rec_op(self, op_on_dense):
-        builder = ak.ArrayBuilder()
+        if len(self.categorical_axes) == 0:
+            return op_on_dense(self._dense_hists[()])
 
+        builder = ak.ArrayBuilder()
         def rec(key, depth):
             axis = list(self.categorical_axes)[-1 * depth]
             for i in range(len(axis)):

--- a/topcoffea/modules/sparseHist.py
+++ b/topcoffea/modules/sparseHist.py
@@ -257,7 +257,7 @@ class SparseHist(hist.Hist, family=hist):
         if not as_dict:
             key = ", ".join([f"'{name}': ..." for name in self._cat_names])
             raise ValueError(f"If not a dict, only view of particular dense histograms is currently supported. Use h[{{{key}}}].view(flow=...) instead.")
-        return {k: h.values(flow=flow) for k, h in self._dense_hists}
+        return {self.index_to_categories(k): h.view(flow=flow) for k, h in self._dense_hists.items()}
 
     def integrate(self, name: str, value=None):
         if value is None:

--- a/topcoffea/modules/sparseHist.py
+++ b/topcoffea/modules/sparseHist.py
@@ -1,0 +1,197 @@
+#! /usr/bin/env python
+
+import hist
+import boost_histogram as bh
+
+from itertools import chain, product, repeat
+
+from typing import Any, List, Mapping, Union, Sequence
+
+
+class SparseHist(hist.Hist, family=hist):
+    def __init__(self, *, categorical_axes, dense_axes, **kwargs):
+        self._init_args = dict(kwargs)
+
+        # actual "histogram". One histogram with one dense axis per combination of categorical bins.
+        self._dense_hists: dict[tuple, hist.Hist] = {}
+
+        self._cat_names = list(axis.name for axis in categorical_axes)
+        self._dense_axes = list(dense_axes)
+
+        # we use self to keep track of the bins in the categorical axes.
+        super().__init__(*categorical_axes, storage="Double")
+        self.axes = hist.axis.NamedAxesTuple(chain(super().axes, self._dense_axes))
+
+        if len(self._cat_names) < 1 or len(self._dense_axes) < 1:
+            raise ValueError("At least one categorical axis and one dense axis should be specified.")
+
+        if not all(map(lambda a: isinstance(a, (hist.axis.StrCategory, hist.axis.IntCategory)), self.categorical_axes)):
+            raise ValueError("Category axes should be of type hist.axis.StrCategory or hist.axis.IntCategory")
+
+    def __str__(self):
+        return repr(self)
+
+    def _split_axes(self, axes: dict):
+        """ Split axes dictionaries in categorical or dense.
+        Axes returned in the order they were created. All axes of the histogram should be specified.
+        """
+        cats = {axis.name: axes[axis.name] for axis in self.categorical_axes}
+        nocats = {axis.name: axes[axis.name] for axis in self._dense_axes}
+        return (cats, nocats)
+
+    def categories_to_index(self, bins: Union[Sequence, Mapping], collapsed=None):
+        if collapsed is None:
+            collapsed = repeat(False)
+        return tuple(axis.index(bin) for axis, bin, mask in zip(self.categorical_axes, bins, collapsed) if not mask)
+
+    def index_to_categories(self, indices: Sequence, collapsed=None):
+        if collapsed is None:
+            collapsed = repeat(True)
+        return tuple(axis[index] for index, axis, mask in zip(indices, self.categorical_axes, collapsed) if not mask)
+
+    @property
+    def categorical_axes(self):
+        return hist.axis.NamedAxesTuple(self.axes[name] for name in self._cat_names)
+
+    @property
+    def categorical_keys(self):
+        return chain(*self.categorical_axes)
+
+    def _fill_bookkeep(self, *args, **kwargs):
+        super().fill(*args, **kwargs)
+
+    def fill(self, weight=None, sample=None, threads=None, **kwargs):
+        cats, nocats = self._split_axes(kwargs)
+
+        # fill the bookkeeping first, so that the index of the key exists.
+        self._fill_bookkeep(**cats)
+
+        sparse_key = self.categories_to_index(tuple(kwargs[name] for name in self._cat_names))
+        try:
+            h = self._dense_hists[sparse_key]
+        except KeyError:
+            h = hist.Hist(*self._dense_axes, **self._init_args)
+            self._dense_hists[sparse_key] = h
+
+        return h.fill(weight=weight, sample=sample, threads=threads, **nocats)
+
+    def _to_bin(self, cat_name, value, offset=0):
+        """ Converts category value into its index slice in a StrCategory or IntCategory axis. """
+        if isinstance(value, int):
+            # already an index
+            if value > -1:
+                return value + offset
+            else:
+                return len(self._bookkeep_hist.axes[cat_name]) + value + offset
+        elif isinstance(value, str):
+            return self.categorical_axes[cat_name].index(value) + offset
+        elif isinstance(value, complex):
+            return self.categorical_axes[cat_name].index(int(value.imag)) + offset
+        elif isinstance(value, bh.tag.loc):
+            return self._to_bin(cat_name, value.value, value.offset)
+        elif isinstance(value, slice):
+            start = value.start if value.start else 0
+            stop = value.stop if value.stop else len(self.axes[cat_name])
+            step = value.step if value.step else 1
+            return slice(
+                self._to_bin(cat_name, start, offset),
+                self._to_bin(
+                    cat_name, stop, offset + (stop < 0)  # add 1 if stop negative, e.g. [-1] index
+                ),
+                step,
+            )
+        elif value == sum:
+            return sum
+        elif isinstance(value, Sequence):
+            return tuple(self._to_bin(cat_name, v, offset) for v in value)
+        raise ValueError("Invalid index specification.")
+
+    def _make_full_key(self, key):
+        if isinstance(key, Mapping):
+            full_key = {
+                axis.name: slice(None) for axis in self.axes
+            }
+            full_key.update(key)
+        elif isinstance(key, Sequence):
+            # boost_histogram.tag.loc
+            if len(key) != len(self.axes):
+                raise ValueError("Incorrect dimensions were specified.")
+            full_key = dict(zip((a.name for a in self.axes), key))
+        else:
+            raise ValueError("Index should be a mapping or a tuple.")
+
+        for a in self.categorical_axes:
+            full_key[a.name] = self._to_bin(a.name, full_key[a.name])
+
+        return full_key
+
+    def _from_hists(self, hists: dict, categorical_axes: list, collapsed: Union[None, Sequence] = None):
+        dense_axes = list(hists.values())[0].axes
+
+        new_hist = type(self)(categorical_axes=categorical_axes, dense_axes=dense_axes, **self._init_args)
+        for index_key, dense_hist in hists.items():
+            named_key = self.index_to_categories(index_key, collapsed)
+            new_hist._fill_bookkeep(*named_key)
+            index_key = new_hist.categories_to_index(named_key)
+            if index_key not in new_hist._dense_hists:
+                new_hist._dense_hists[index_key] = hist.Hist(*dense_axes, **self._init_args)
+            new_hist._dense_hists[index_key] += dense_hist
+        return new_hist
+
+    def _from_sum_all(self, hists: dict):
+        dense_axes = list(hists.values())[0].axes
+        new_hist = hist.Hist(*dense_axes, **self._init_args)
+        for dense_hist in hists.values():
+            new_hist += dense_hist
+        return new_hist
+
+    def _from_hists_no_dense(self, hists: dict, categorical_axes: list, collapsed: Union[None, Sequence] = None):
+        new_hist = hist.Hist(*categorical_axes, **self._init_args)
+        for index_key, weight in hists.items():
+            named_key = self.index_to_categories(index_key, collapsed)
+            new_hist.fill(*named_key, weight=weight)
+        return new_hist
+
+    def _filter_dense(self, full_key):
+        def asseq(cat_name, x):
+            if isinstance(x, int):
+                return range(x, x + 1)
+            elif isinstance(x, slice):
+                return range(x.start, x.stop, x.step)
+            elif x == sum:
+                return range(len(self.axes[cat_name]))
+            return x
+
+        cats, nocats = self._split_axes(full_key)
+
+        filtered = {}
+        for sparse_key in product(*(asseq(name, v) for name, v in cats.items())):
+            if sparse_key in self._dense_hists:
+                filtered[sparse_key] = self._dense_hists[sparse_key][tuple(nocats.values())]
+
+        if len(filtered) == 0:
+            raise KeyError("No bins found")
+        return filtered
+
+    def __getitem__(self, key):
+        full_key = self._make_full_key(key)
+        filtered = self._filter_dense(full_key)
+
+        collapsed = [full_key[name] is sum or isinstance(full_key[name], int) for name in self._cat_names]
+        new_cats = [
+            type(axis)([], growth=True, name=axis.name, label=axis.label)
+            for axis, mask in zip(self.categorical_axes, collapsed) if not mask
+        ]
+
+        first = list(filtered.values())[0]
+        if len(new_cats) == 0:
+            if isinstance(first, hist.Hist):
+                return self._from_sum_all(filtered)
+            else:
+                # collapsed to singe value
+                return first
+        if not isinstance(first, hist.Hist):
+            # there was only one dense axis, and it collapse into one value
+            return self._from_hists_no_dense(filtered, new_cats, collapsed)
+        else:
+            return self._from_hists(filtered, new_cats, collapsed)

--- a/topcoffea/modules/sparseHist.py
+++ b/topcoffea/modules/sparseHist.py
@@ -234,14 +234,14 @@ class SparseHist(hist.Hist, family=hist):
         index_key = self._make_index_key(key)
         filtered = self._filter_dense(index_key)
 
-        if len(filtered) == 0:
-            raise KeyError("No bins found")
-
         collapsed = [index_key[name] is sum or isinstance(index_key[name], int) for name in self.categorical_axes.name]
         new_cats = [
             type(axis)([], growth=True, name=axis.name, label=axis.label)
             for axis, mask in zip(self.categorical_axes, collapsed) if not mask
         ]
+
+        if len(filtered) == 0:
+            return self.from_categorical_axes_like(*new_cats)
 
         first = list(filtered.values())[0]
         if not isinstance(first, hist.Hist):

--- a/topcoffea/modules/sparseHist.py
+++ b/topcoffea/modules/sparseHist.py
@@ -299,9 +299,13 @@ class SparseHist(hist.Hist, family=hist):
         else:
             if self._cat_names != other._cat_names:
                 raise ValueError("Category names are different, or in different order, and therefore cannot be merged.")
-            for index, oh in other._dense_hists.items():
-                if index not in self._dense_hists:
-                    self._fill_bookkeep(*other.index_to_categories(index))
+            for index_oh, oh in other._dense_hists.items():
+                cats = other.index_to_categories(index_oh)
+                try:
+                    index = self.categories_to_index(cats)
+                except KeyError:
+                    self._fill_bookkeep(*cats)
+                    index = self.categories_to_index(cats)
                 getattr(self._dense_hists[index], op)(oh)
         return self
 

--- a/topcoffea/modules/sparseHist.py
+++ b/topcoffea/modules/sparseHist.py
@@ -190,7 +190,8 @@ class SparseHist(hist.Hist, family=hist):
             if isinstance(x, int):
                 return range(x, x + 1)
             elif isinstance(x, slice):
-                return range(x.start, x.stop, x.step)
+                step = x.step if isinstance(x.step, int) else 1
+                return range(x.start, x.stop, step)
             elif x == sum:
                 return range(len(self.axes[cat_name]))
             return x
@@ -257,6 +258,11 @@ class SparseHist(hist.Hist, family=hist):
             key = ", ".join([f"'{name}': ..." for name in self._cat_names])
             raise ValueError(f"If not a dict, only view of particular dense histograms is currently supported. Use h[{{{key}}}].view(flow=...) instead.")
         return {k: h.values(flow=flow) for k, h in self._dense_hists}
+
+    def integrate(self, name: str, value=None):
+        if value is None:
+            value = sum
+        return self[{name: value}]
 
     def remove(self, axis_name, bins):
         """Remove bins from a categorical axis

--- a/topcoffea/modules/topeft_axes.py
+++ b/topcoffea/modules/topeft_axes.py
@@ -1,0 +1,63 @@
+info = {
+    "invmass": {
+        "regular": (20, 0, 1000),
+        "label": r"$m_{\ell\ell}$ (GeV) ",
+    },
+    "ptbl": {
+        "regular": (40, 0, 1000),
+        "variable": [0, 100, 200, 400],
+        "label": r"$p_{T}^{b\mathrm{-}jet+\ell_{min(dR)}}$ (GeV) ",
+    },
+    "ptz": {
+        "regular": (12, 0, 600),
+        "variable": [0, 200, 300, 400, 500],
+        "label": r"$p_{T}$ Z (GeV) ",
+    },
+    "njets": {
+        "regular": (10, 0, 10),
+        "variable_multi": {
+            "2l": [4, 5, 6, 7],
+            "3l": [2, 3, 4, 5],
+            "4l": [2, 3, 4],
+        },
+        "label": r"Jet multiplicity ",
+    },
+    "nbtagsl": {"regular": (5, 0, 5), "label": r"Loose btag multiplicity "},
+    "l0pt": {
+        "regular": (10, 0, 500),
+        "variable": [0, 50, 100, 200],
+        "label": r"Leading lep $p_{T}$ (GeV) ",
+    },
+    "l1pt": {"regular": (10, 0, 100), "label": r"Subleading lep $p_{T}$ (GeV) "},
+    "l1eta": {"regular": (20, -2.5, 2.5), "label": r"Subleading $\eta$ "},
+    "j0pt": {"regular": (10, 0, 500), "label": r"Leading jet  $p_{T}$ (GeV) "},
+    "b0pt": {"regular": (10, 0, 500), "label": r"Leading b jet  $p_{T}$ (GeV) "},
+    "l0eta": {"regular": (20, -2.5, 2.5), "label": r"Leading lep $\eta$ "},
+    "j0eta": {"regular": (30, -3, 3), "label": r"Leading jet  $\eta$ "},
+    "ht": {
+        "regular": (20, 0, 1000),
+        "variable": [0, 300, 500, 800],
+        "label": r"H$_{T}$ (GeV) ",
+    },
+    "met": {"regular": (20, 0, 400), "label": r"MET (GeV)"},
+    "ljptsum": {
+        "regular": (11, 0, 1100),
+        "variable": [0, 400, 600, 1000],
+        "label": r"S$_{T}$ (GeV) ",
+    },
+    "o0pt": {
+        "regular": (10, 0, 500),
+        "variable": [0, 100, 200, 400],
+        "label": r"Leading l or b jet $p_{T}$ (GeV)",
+    },
+    "bl0pt": {
+        "regular": (10, 0, 500),
+        "variable": [0, 100, 200, 400],
+        "label": r"Leading (b+l) $p_{T}$ (GeV) ",
+    },
+    "lj0pt": {
+        "regular": (12, 0, 600),
+        "variable": [0, 150, 250, 500],
+        "label": r"Leading pt of pair from l+j collection (GeV) ",
+    },
+}

--- a/topcoffea/modules/utils.py
+++ b/topcoffea/modules/utils.py
@@ -160,7 +160,7 @@ def dump_to_pkl(out_name,out_file):
 def get_hist_from_pkl(path_to_pkl,allow_empty=True):
     h = pickle.load( gzip.open(path_to_pkl) )
     if not allow_empty:
-        h = {k:v for k,v in h.items() if v.values() != {}}
+        h = {k:v for k,v in h.items() if v.eval({}) != {}}
     return h
 
 # Check if the contents of two dictionaries of lists agree


### PR DESCRIPTION
Main changes are in the histEFT.py file.  API changes:

- Axes need to follow the syntax from schikit HEP.
- For scikit addition to work, axes should be in the same order, have the same name, and have the same label. Thus, HistEFT enforces that there should be exactly one dense axis specified, and that it should be the last one listed in __init__.
- Removed most code related to sumw2. There is still some in YieldTools which I didn't know how to modify.
- Added a small module (axes.py) which has a dictionary with the description of the axes for topeft.py It lists the regular or variable edges as needed.  Currently only variable edges work, as the regular involve a rebinning that can't be done right now.
- Since values() returns the bin counts in hist.Hist, added a new function call  h.eval(values) that evaluates the histogram.
- h.eval has a required argument. If evaluating for sm, use None or {}. It receives either a dict of coefficients or an array.
- Removed the set_wc_coefficients* functions and the internal self_wcs. Instead:
- h.eval(wcs) method returns what `h.set_wc_coefficients(wcs);  h.values()`  would do.
- h.eval has a parameter to include the under/overflow bins. This seems to match what values() did, but it didn't make much sense to me. Should eval only return proper bins?
- Regarding overflow, hist.Hist has only the option to include it or not (boolean). There is not a special option for NaN. NaN gets added to overflow bins.
- The new HistEFT cannot be used as a regular hist.Hist, as If exactly one dense axis needs to be defined. If no wc names coefficients are specified, it is assumed that the wc coefficients for filling the histogram are 1.
- Previous hist iterated on the keys of h._sumw.  Added a function  h.spare_keys() that generates all the possible combination of keys.
- Added some functions for compatibility, such as group() and integrate().
- eft_helper.calc_eft_weights  seems to depend strongly on the structure of these particular histograms, so maybe is a good idea to move it to histEFT.HistEFT
- Some pickled data (e.g. data/triggerSF/*) depend on the old HistEFT module and need to be regenerated before HistEFT can be removed.

All but two unit tests are working:
- tests/test_HistEFT_add.py::test_split_by_terms.  h.split_by_terms needs to be rewritten.
- tests/test_yields.py::test_compare_yields_after_processor.   The values generated are 0, so I think that there is an error on which bins are being looked at (e.g. the undeflow bins) in YieldTools or datacard related files. I didn't understand the code enough to fix this one.

If you have any comments I can fix those, but probably the two failing tests need someone that understand the related physics.
