### PR TITLE
Conda swap space

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,12 @@ jobs:
       - name: Add conda to system path
         run: |
           echo $CONDA/bin >> $GITHUB_PATH 
-
+      
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
+      
       - name: Create conda env and install dependencies
         run: |
           conda config --set channel_priority strict

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
           echo $CONDA/bin >> $GITHUB_PATH 
       
       - name: Set Swap Space
-        uses: pierotofy/set-swap-space@master
+        uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c
         with:
           swap-size-gb: 10
       


### PR DESCRIPTION
Increase swap space to fixe conda timing out. Same fix that was merged in TopCoffea (https://github.com/TopEFT/topcoffea/pull/11)