### PR TITLE
Calendar Coffea processor and remove futures executor

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -305,7 +305,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         # We only calculate these values if not isData
         # Note: add() will generally modify up/down weights, so if these are needed for any reason after this point, we should instead pass copies to add()
         # Note: Here we will to the weights object the SFs that do not depend on any of the forthcoming loops
-        weights_obj_base = coffea.analysis_tools.Weights(len(events),storeIndividual=True)
+        weights_obj_base = coffea.analysis_tools.Weights(None,storeIndividual=True)
         if not isData:
 
             # If this is no an eft sample, get the genWeight

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -6,6 +6,7 @@ import time
 import cloudpickle
 import gzip
 import os
+import dask
 
 from coffea import processor
 from coffea.nanoevents import NanoAODSchema
@@ -320,13 +321,49 @@ if __name__ == '__main__':
     tstart = time.time()
 
     if executor == "futures":
-        exec_instance = processor.futures_executor(workers=nworkers)
-        runner = processor.Runner(exec_instance, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks)
+        runner = processor(schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks)
+        output = dask.compute(processor_instance)
     elif executor ==  "work_queue":
         executor = processor.WorkQueueExecutor(**executor_args)
         runner = processor.Runner(executor, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks, skipbadfiles=False, xrootdtimeout=180)
+        workers = wq.Factory(
+            # local runs:
+            batch_type="condor",
+            manager_host_port=f"localhost:{wq_port}"
+            # with a batch system, e.g., condor.
+            # (If coffea not at the installation site, then a conda
+            # environment_file should be defined in the work_queue_executor_args.)
+            # batch_type="condor", manager_name=wq_manager_name
+        )
+        
+        #workers.max_workers = 2
+        #workers.min_workers = 1
+        #workers.cores = 2
+        #workers.memory = 1000  # MB
+        #workers.disk = 2000  # MB
+        #workers.password = my_password_file
+        
+        # Instead of declaring the python environment per task, you can set it in
+        # the factory directly. This is useful if you are going to run a workflow
+        # several times using the same set of workers. It also ensures that the worker
+        # itself executes in a friendly environment.
+        # workers.python_package = "coffea-env.tar.gz"
+        #
+        # The factory tries to write temporary files to $TMPDIR (usually /tmp). When
+        # this is not available, or causes errors, this scracth directory can be
+        # manually set.
+        # workers.scratch_dir = "./my-scratch-dir"
+        
+        with workers:
+            # define the Runner instance
+            run_fn = Runner(
+                executor=executor,
+                chunksize=chunksize,
+                maxchunks=maxchunks,  # change this to None for a large run
+            )
+            # execute the analysis on the given dataset
+            output = run_fn(fileset, "Events", MyProcessor())
 
-    output = runner(flist, treename, processor_instance)
 
     dt = time.time() - tstart
 

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -325,7 +325,7 @@ if __name__ == '__main__':
         output = dask.compute(processor_instance)
     elif executor ==  "work_queue":
         executor = processor.WorkQueueExecutor(**executor_args)
-        runner = processor.Runner(executor, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks, skipbadfiles=False, xrootdtimeout=180)
+        runner = processor(executor, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks, skipbadfiles=False, xrootdtimeout=180)
         workers = wq.Factory(
             # local runs:
             batch_type="condor",
@@ -355,14 +355,8 @@ if __name__ == '__main__':
         # workers.scratch_dir = "./my-scratch-dir"
         
         with workers:
-            # define the Runner instance
-            run_fn = Runner(
-                executor=executor,
-                chunksize=chunksize,
-                maxchunks=maxchunks,  # change this to None for a large run
-            )
             # execute the analysis on the given dataset
-            output = run_fn(fileset, "Events", MyProcessor())
+            output = runner(processor_instance)
 
 
     dt = time.time() - tstart

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -321,7 +321,6 @@ if __name__ == '__main__':
     tstart = time.time()
 
     if executor == "futures":
-        runner = processor(schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks)
         output = dask.compute(processor_instance)
     elif executor ==  "work_queue":
         executor = processor.WorkQueueExecutor(**executor_args)

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -326,37 +326,7 @@ if __name__ == '__main__':
     elif executor ==  "work_queue":
         executor = processor.WorkQueueExecutor(**executor_args)
         runner = processor(executor, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks, skipbadfiles=False, xrootdtimeout=180)
-        workers = wq.Factory(
-            # local runs:
-            batch_type="condor",
-            manager_host_port=f"localhost:{wq_port}"
-            # with a batch system, e.g., condor.
-            # (If coffea not at the installation site, then a conda
-            # environment_file should be defined in the work_queue_executor_args.)
-            # batch_type="condor", manager_name=wq_manager_name
-        )
-        
-        #workers.max_workers = 2
-        #workers.min_workers = 1
-        #workers.cores = 2
-        #workers.memory = 1000  # MB
-        #workers.disk = 2000  # MB
-        #workers.password = my_password_file
-        
-        # Instead of declaring the python environment per task, you can set it in
-        # the factory directly. This is useful if you are going to run a workflow
-        # several times using the same set of workers. It also ensures that the worker
-        # itself executes in a friendly environment.
-        # workers.python_package = "coffea-env.tar.gz"
-        #
-        # The factory tries to write temporary files to $TMPDIR (usually /tmp). When
-        # this is not available, or causes errors, this scracth directory can be
-        # manually set.
-        # workers.scratch_dir = "./my-scratch-dir"
-        
-        with workers:
-            # execute the analysis on the given dataset
-            output = runner(processor_instance)
+        output = runner(processor_instance)
 
 
     dt = time.time() - tstart

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,10 @@
-name: coffea-env
+name: coffea2023
 channels:
   - conda-forge
 dependencies:
-  - conda-forge::python=3.9
-  - numpy=1.23.5
-  - coffea=0.7.21
+  - conda-forge::python=3.10
+  - numpy
+  - coffea
   - ndcctools
   - conda-pack
   - dill


### PR DESCRIPTION
This PR removes instances of `len` in the processor and the `FuturesExecutor` in favor of `dask.compute()`