### PR TITLE
Pin numpy to 1.23.5 to fix a conflict between coffea and numpy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,9 @@
-name: coffea-env
+name: clib-env
 channels:
   - conda-forge
 dependencies:
   - conda-forge::python=3.9
-  - numpy
+  - numpy=1.23.5
   - coffea<2023
   - ndcctools
   - conda-pack

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: clib-env
+name: coffea-env
 channels:
   - conda-forge
 dependencies:


### PR DESCRIPTION
While setting the local environment to include `correction_lib` to `top_eft`, I have obtained this when running the processor with futures:

`
Traceback (most recent call last):
  File "/afs/crc.nd.edu/user/a/apiccine/miniconda3/envs/clib-env/lib/python3.9/site-packages/coffea/processor/executor.py", line 786, in _processwith
    merged = _watcher(FH, self, reducer, pool)
  File "/afs/crc.nd.edu/user/a/apiccine/miniconda3/envs/clib-env/lib/python3.9/site-packages/coffea/processor/executor.py", line 402, in _watcher
    batch = FH.fetch(len(FH.completed))
  File "/afs/crc.nd.edu/user/a/apiccine/miniconda3/envs/clib-env/lib/python3.9/site-packages/coffea/processor/executor.py", line 286, in fetch
    raise bad_futures[0].exception()
TypeError: __class__ assignment: 'NanoEventsArray' object layout differs from 'Array'
Traceback (most recent call last):
  File "/afs/crc.nd.edu/user/a/apiccine/correction-lib/topeft/analysis/topeft_run2/run_analysis.py", line 330, in <module>
    output = runner(flist, treename, processor_instance)
  File "/afs/crc.nd.edu/user/a/apiccine/miniconda3/envs/clib-env/lib/python3.9/site-packages/coffea/processor/executor.py", line 1700, in __call__
    wrapped_out = self.run(fileset, processor_instance, treename)
  File "/afs/crc.nd.edu/user/a/apiccine/miniconda3/envs/clib-env/lib/python3.9/site-packages/coffea/processor/executor.py", line 1848, in run
    wrapped_out, e = executor(chunks, closure, None)
  File "/afs/crc.nd.edu/user/a/apiccine/miniconda3/envs/clib-env/lib/python3.9/site-packages/coffea/processor/executor.py", line 817, in __call__
    return _processwith(pool=poolinstance, mergepool=mergepoolinstance)
  File "/afs/crc.nd.edu/user/a/apiccine/miniconda3/envs/clib-env/lib/python3.9/site-packages/coffea/processor/executor.py", line 801, in _processwith
    raise e from None
  File "/afs/crc.nd.edu/user/a/apiccine/miniconda3/envs/clib-env/lib/python3.9/site-packages/coffea/processor/executor.py", line 786, in _processwith
    merged = _watcher(FH, self, reducer, pool)
  File "/afs/crc.nd.edu/user/a/apiccine/miniconda3/envs/clib-env/lib/python3.9/site-packages/coffea/processor/executor.py", line 402, in _watcher
    batch = FH.fetch(len(FH.completed))
  File "/afs/crc.nd.edu/user/a/apiccine/miniconda3/envs/clib-env/lib/python3.9/site-packages/coffea/processor/executor.py", line 286, in fetch
    raise bad_futures[0].exception()
TypeError: __class__ assignment: 'NanoEventsArray' object layout differs from 'Array'
`

To fix this, I downgraded `numpy` from `1.26.4` to `1.23.5`. As a consequence, it would be good to pin `numpy` to this version in `environment.yml`.