### PR TITLE
Fix typo in path for `test_make_1d_quad_plots.py`

### DIFF
--- a/tests/test_make_1d_quad_plots.py
+++ b/tests/test_make_1d_quad_plots.py
@@ -6,12 +6,12 @@ def test_make_1d_quad_plots():
         "python",
         "analysis/topeft_run2/make_1d_quad_plots.py",
         "-i",
-        "ttHJet_UL17_R1B14_NAOD-00000_10194.root",
+        "ttHJet_UL17_R1B14_NAOD-00000_10194_NDSkim.root",
         "-r",
         "./"
     ]
 
     # Run make_1d_quad
-    subprocess.run(args)
+    assert subprocess.run(args)
 
     glob.glob('tmp_quad_plos*')


### PR DESCRIPTION
The CI script `test_make_1d_quad_plots.py` has been failing