### PR TITLE
Adding separate hist for sumw2

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -67,6 +67,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         self._samples = samples
         self._wc_names_lst = wc_names_lst
+        self._isEFT = self._samples[dataset]["WCnames"] != []
         self._dtype = dtype
 
         proc_axis = hist.axis.StrCategory([], name="process", growth=True)
@@ -936,13 +937,16 @@ class AnalysisProcessor(processor.ProcessorABC):
                                         if ((dense_axis_name in ["o0pt","b0pt","bl0pt"]) & ("CR" in ch_name)): continue
 
                                         hout[dense_axis_name].fill(**axes_fill_info_dict)
+                                        sumw2 = np.zeros_like(weights_flat)
+                                        if not self._isEFT: # Only SM (bkg) and data
+                                            sumw2 = np.square(weights_flat)
                                         axes_fill_info_dict = {
                                             dense_axis_name+"_sumw2" : dense_axis_vals[all_cuts_mask],
                                             "channel"       : ch_name,
                                             "appl"          : appl,
                                             "process"       : histAxisName,
                                             "systematic"    : wgt_fluct,
-                                            "weight"        : np.square(weights_flat),
+                                            "weight"        : sumw2,
                                             "eft_coeff"     : eft_coeffs_cut,
                                         }
                                         hout[dense_axis_name+"_sumw2"].fill(**axes_fill_info_dict)

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -937,18 +937,16 @@ class AnalysisProcessor(processor.ProcessorABC):
                                         if ((dense_axis_name in ["o0pt","b0pt","bl0pt"]) & ("CR" in ch_name)): continue
 
                                         hout[dense_axis_name].fill(**axes_fill_info_dict)
-                                        if not isEFT: # Only SM (bkg) and data
-                                            sumw2 = np.square(weights_flat)
-                                            axes_fill_info_dict = {
-                                                dense_axis_name+"_sumw2" : dense_axis_vals[all_cuts_mask],
-                                                "channel"       : ch_name,
-                                                "appl"          : appl,
-                                                "process"       : histAxisName,
-                                                "systematic"    : wgt_fluct,
-                                                "weight"        : sumw2,
-                                                "eft_coeff"     : eft_coeffs_cut,
-                                            }
-                                            hout[dense_axis_name+"_sumw2"].fill(**axes_fill_info_dict)
+                                        axes_fill_info_dict = {
+                                            dense_axis_name+"_sumw2" : dense_axis_vals[all_cuts_mask],
+                                            "channel"       : ch_name,
+                                            "appl"          : appl,
+                                            "process"       : histAxisName,
+                                            "systematic"    : wgt_fluct,
+                                            "weight"        : np.square(weights_flat),
+                                            "eft_coeff"     : eft_coeffs_cut,
+                                        }
+                                        hout[dense_axis_name+"_sumw2"].fill(**axes_fill_info_dict)
 
                                         # Do not loop over lep flavors if not self._split_by_lepton_flavor, it's a waste of time and also we'd fill the hists too many times
                                         if not self._split_by_lepton_flavor: break

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -67,7 +67,6 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         self._samples = samples
         self._wc_names_lst = wc_names_lst
-        self._isEFT = self._samples[dataset]["WCnames"] != []
         self._dtype = dtype
 
         proc_axis = hist.axis.StrCategory([], name="process", growth=True)
@@ -148,6 +147,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         # Dataset parameters
         dataset = events.metadata["dataset"]
+        isEFT   = self._samples[dataset]["WCnames"] != []
 
         isData             = self._samples[dataset]["isData"]
         histAxisName       = self._samples[dataset]["histAxisName"]
@@ -938,7 +938,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
                                         hout[dense_axis_name].fill(**axes_fill_info_dict)
                                         sumw2 = np.zeros_like(weights_flat)
-                                        if not self._isEFT: # Only SM (bkg) and data
+                                        if not isEFT: # Only SM (bkg) and data
                                             sumw2 = np.square(weights_flat)
                                         axes_fill_info_dict = {
                                             dense_axis_name+"_sumw2" : dense_axis_vals[all_cuts_mask],

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -80,9 +80,15 @@ class AnalysisProcessor(processor.ProcessorABC):
                 dense_axis = hist.axis.Variable(
                     info["variable"], name=name, label=info["label"]
                 )
+                sumw2_axis = hist.axis.Variable(
+                    info["variable"], name=name+"_sumw2", label=info["label"] + " sum of w^2"
+                )
             else:
                 dense_axis = hist.axis.Regular(
                     *info["regular"], name=name, label=info["label"]
+                )
+                sumw2_axis = hist.axis.Regular(
+                    *info["regular"], name=name+"_sumw2", label=info["label"] + " sum of w^2"
                 )
             histograms[name] = HistEFT(
                 proc_axis,
@@ -90,6 +96,16 @@ class AnalysisProcessor(processor.ProcessorABC):
                 syst_axis,
                 appl_axis,
                 dense_axis,
+                wc_names=wc_names_lst,
+                label=r"Events",
+                rebin=rebin
+            )
+            histograms[name+"_sumw2"] = HistEFT(
+                proc_axis,
+                chan_axis,
+                syst_axis,
+                appl_axis,
+                sumw2_axis,
                 wc_names=wc_names_lst,
                 label=r"Events",
                 rebin=rebin
@@ -920,6 +936,16 @@ class AnalysisProcessor(processor.ProcessorABC):
                                         if ((dense_axis_name in ["o0pt","b0pt","bl0pt"]) & ("CR" in ch_name)): continue
 
                                         hout[dense_axis_name].fill(**axes_fill_info_dict)
+                                        axes_fill_info_dict = {
+                                            dense_axis_name+"_sumw2" : dense_axis_vals[all_cuts_mask],
+                                            "channel"       : ch_name,
+                                            "appl"          : appl,
+                                            "process"       : histAxisName,
+                                            "systematic"    : wgt_fluct,
+                                            "weight"        : np.square(weights_flat),
+                                            "eft_coeff"     : eft_coeffs_cut,
+                                        }
+                                        hout[dense_axis_name+"_sumw2"].fill(**axes_fill_info_dict)
 
                                         # Do not loop over lep flavors if not self._split_by_lepton_flavor, it's a waste of time and also we'd fill the hists too many times
                                         if not self._split_by_lepton_flavor: break

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -937,7 +937,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                                         if ((dense_axis_name in ["o0pt","b0pt","bl0pt"]) & ("CR" in ch_name)): continue
 
                                         hout[dense_axis_name].fill(**axes_fill_info_dict)
-                                        sumw2 = np.zeros_like(weights_flat)
+                                        sumw2 = np.ones_like(weights_flat)
                                         if not isEFT: # Only SM (bkg) and data
                                             sumw2 = np.square(weights_flat)
                                         axes_fill_info_dict = {

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -937,19 +937,18 @@ class AnalysisProcessor(processor.ProcessorABC):
                                         if ((dense_axis_name in ["o0pt","b0pt","bl0pt"]) & ("CR" in ch_name)): continue
 
                                         hout[dense_axis_name].fill(**axes_fill_info_dict)
-                                        sumw2 = np.ones_like(weights_flat)
                                         if not isEFT: # Only SM (bkg) and data
                                             sumw2 = np.square(weights_flat)
-                                        axes_fill_info_dict = {
-                                            dense_axis_name+"_sumw2" : dense_axis_vals[all_cuts_mask],
-                                            "channel"       : ch_name,
-                                            "appl"          : appl,
-                                            "process"       : histAxisName,
-                                            "systematic"    : wgt_fluct,
-                                            "weight"        : sumw2,
-                                            "eft_coeff"     : eft_coeffs_cut,
-                                        }
-                                        hout[dense_axis_name+"_sumw2"].fill(**axes_fill_info_dict)
+                                            axes_fill_info_dict = {
+                                                dense_axis_name+"_sumw2" : dense_axis_vals[all_cuts_mask],
+                                                "channel"       : ch_name,
+                                                "appl"          : appl,
+                                                "process"       : histAxisName,
+                                                "systematic"    : wgt_fluct,
+                                                "weight"        : sumw2,
+                                                "eft_coeff"     : eft_coeffs_cut,
+                                            }
+                                            hout[dense_axis_name+"_sumw2"].fill(**axes_fill_info_dict)
 
                                         # Do not loop over lep flavors if not self._split_by_lepton_flavor, it's a waste of time and also we'd fill the hists too many times
                                         if not self._split_by_lepton_flavor: break

--- a/analysis/topeft_run2/make_cards.py
+++ b/analysis/topeft_run2/make_cards.py
@@ -26,7 +26,7 @@ error  = {condor_dir}/job_{idx}.err
 log    = {condor_dir}/job_{idx}.log
 
 request_cpus = 1
-request_memory = 4096
+request_memory = 8192
 request_disk = 1024
 
 transfer_input_files = make_cards.py,selectedWCs.txt

--- a/topeft/modules/compatibility.py
+++ b/topeft/modules/compatibility.py
@@ -6,7 +6,7 @@ def add_sumw2_stub(eval_d, sumw2=False):
     eval_d2 = {}
     for k, v in eval_d.items():
         if not sumw2:
-            eval_d2[k] = np.stack((v, np.sqrt(sumw2[k])))
-        else:
             eval_d2[k] = np.stack((v, np.broadcast_to(np.zeros((1,)), len(v))))
+        else:
+            eval_d2[k] = np.stack((v, np.sqrt(sumw2[k])))
     return eval_d2

--- a/topeft/modules/compatibility.py
+++ b/topeft/modules/compatibility.py
@@ -9,6 +9,5 @@ def add_sumw2_stub(eval_d, sumw2=False):
             eval_d2[k] = np.stack((v, np.broadcast_to(np.zeros((1,)), len(v))))
         else:
             variance = sumw2[k]
-            variance[variance<0] = 0
             eval_d2[k] = np.stack((v, variance))
     return eval_d2

--- a/topeft/modules/compatibility.py
+++ b/topeft/modules/compatibility.py
@@ -8,5 +8,7 @@ def add_sumw2_stub(eval_d, sumw2=False):
         if not sumw2:
             eval_d2[k] = np.stack((v, np.broadcast_to(np.zeros((1,)), len(v))))
         else:
-            eval_d2[k] = np.stack((v, np.sqrt(sumw2[k])))
+            err = sumw2[k]
+            err[err<0] = 0
+            eval_d2[k] = np.stack((v, np.sqrt(err)))
     return eval_d2

--- a/topeft/modules/compatibility.py
+++ b/topeft/modules/compatibility.py
@@ -1,9 +1,13 @@
+import hist
 import numpy as np
 
 
-def add_sumw2_stub(eval_d):
+def add_sumw2_stub(eval_d, sumw2=False):
     # compatibility with the coffea.Hist. add a row of zeros for sumw2.
     eval_d2 = {}
     for k, v in eval_d.items():
-        eval_d2[k] = np.stack((v, np.broadcast_to(np.zeros((1,)), len(v))))
+        if not sumw2:
+            eval_d2[k] = np.stack((v, np.sqrt(sumw2[k])))
+        else:
+            eval_d2[k] = np.stack((v, np.broadcast_to(np.zeros((1,)), len(v))))
     return eval_d2

--- a/topeft/modules/compatibility.py
+++ b/topeft/modules/compatibility.py
@@ -1,4 +1,3 @@
-import hist
 import numpy as np
 
 

--- a/topeft/modules/compatibility.py
+++ b/topeft/modules/compatibility.py
@@ -8,7 +8,7 @@ def add_sumw2_stub(eval_d, sumw2=False):
         if not sumw2:
             eval_d2[k] = np.stack((v, np.broadcast_to(np.zeros((1,)), len(v))))
         else:
-            err = sumw2[k]
-            err[err<0] = 0
-            eval_d2[k] = np.stack((v, np.sqrt(err)))
+            variance = sumw2[k]
+            variance[variance<0] = 0
+            eval_d2[k] = np.stack((v, variance))
     return eval_d2

--- a/topeft/modules/dataDrivenEstimation.py
+++ b/topeft/modules/dataDrivenEstimation.py
@@ -119,7 +119,7 @@ class DataDrivenProducer:
 
                         # now we actually make the subtraction
                         # var(A - B) = var(A) + var(B)
-                        if '_sumw2' not in key:
+                        if not key.endswith("_sumw2"):
                             hPromptSub.scale(-1)
                         hFakes += hPromptSub
                         # now adding them to the list of processes:

--- a/topeft/modules/dataDrivenEstimation.py
+++ b/topeft/modules/dataDrivenEstimation.py
@@ -118,7 +118,9 @@ class DataDrivenProducer:
                         hPromptSub = hPromptSub.remove("systematic", syst_var_idet_rm_lst)
 
                         # now we actually make the subtraction
-                        hPromptSub.scale(-1)
+                        # var(A - B) = var(A) + var(B)
+                        if '_sumw2' not in key:
+                            hPromptSub.scale(-1)
                         hFakes += hPromptSub
                         # now adding them to the list of processes:
                         if newhist==None:

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -794,7 +794,6 @@ class DatacardMaker():
         else:
             msg = "No sumw2 histogram found! Setting errors to 0"
             print(msg)
-            h_sumw2 = None
         ch_hist = h.integrate("channel",[ch])
         ch_sumw2 = h_sumw2 if h_sumw2 is None else h_sumw2.integrate("channel",[ch])
         data_obs = np.zeros((2, ch_hist.dense_axis.extent))

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -814,7 +814,7 @@ class DatacardMaker():
                 if 'fakes' in p and '4l' in ch:
                     continue
                 proc_hist = ch_hist.integrate("process",[p])
-                proc_sumw2 = ch_sumw2 if ch_sumw2 is not None else ch_sumw2.integrate("process",[p])
+                proc_sumw2 = ch_sumw2 if ch_sumw2 is None else ch_sumw2.integrate("process",[p])
                 if self.verbose:
                     print(f"Decomposing {ch}-{p}")
                 decomposed_templates = self.decompose(proc_hist,proc_sumw2,wcs)
@@ -895,7 +895,7 @@ class DatacardMaker():
                                 all_shapes.add(syst_base)
                                 text_card_info[proc_name]["shapes"].add(syst_base)
                             syst_width = max(len(syst),syst_width)
-                        zero_out_sumw2 = p != "fakes" # Zero out sumw2 for all proc but fakes, so that we only do auto stats for fakes
+                        zero_out_sumw2 = p != "fakes" and "close" not in p # Zero out sumw2 for all proc but fakes, so that we only do auto stats for fakes
                         f[hist_name] = to_hist(arr,hist_name,zero_wgts=zero_out_sumw2)
 
                         num_h += 1

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -422,8 +422,9 @@ class DatacardMaker():
         for km_dist, h in self.hists.items():
             if h.empty():
                 continue
-            km_dist_sumw = km_dist.replace('_sumw2','')
-            if self.var_lst and km_dist not in self.var_lst and km_dist_sumw not in self.var_lst:
+            km_dist_missing = km_dist not in self.var_lst
+            km_base_dist_missing = km_dist.replace('_sumw2','') not in self.var_lst
+            if self.var_lst and km_dist_missing and km_base_dist_missing:
                 continue
             print(f"Loading: {km_dist}")
             # Remove processes that we don't include in the datacard

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -788,9 +788,10 @@ class DatacardMaker():
         outf_root_name = self.FNAME_TEMPLATE.format(cat=ch,kmvar=km_dist,ext="root")
 
         h = self.hists[km_dist]
-        try:
+        h_sumw2 = None
+        if f"{km_dist}_sumw2" in self.hists:
             h_sumw2 = self.hists[km_dist+"_sumw2"]
-        except KeyError:
+        else:
             msg = "No sumw2 histogram found! Setting errors to 0"
             print(msg)
             h_sumw2 = None

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -796,7 +796,7 @@ class DatacardMaker():
             print(msg)
             h_sumw2 = None
         ch_hist = h.integrate("channel",[ch])
-        ch_sumw2 = h_sumw2.integrate("channel",[ch]) if h_sumw2 is not None else h_sumw2
+        ch_sumw2 = h_sumw2 if h_sumw2 is None else h_sumw2.integrate("channel",[ch])
         data_obs = np.zeros((2, ch_hist.dense_axis.extent))
 
         print(f"Generating root file: {outf_root_name}")
@@ -814,7 +814,7 @@ class DatacardMaker():
                 if 'fakes' in p and '4l' in ch:
                     continue
                 proc_hist = ch_hist.integrate("process",[p])
-                proc_sumw2 = ch_sumw2.integrate("process",[p]) if ch_sumw2 is not None else ch_sumw2
+                proc_sumw2 = ch_sumw2 if ch_sumw2 is not None else ch_sumw2.integrate("process",[p])
                 if self.verbose:
                     print(f"Decomposing {ch}-{p}")
                 decomposed_templates = self.decompose(proc_hist,proc_sumw2,wcs)

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -422,7 +422,8 @@ class DatacardMaker():
         for km_dist, h in self.hists.items():
             if h.empty():
                 continue
-            if self.var_lst and km_dist not in self.var_lst and km_dist.replace("_sumw2", "") not in self.var_lst:
+            km_dist_sumw = km_dist.replace('_sumw2','')
+            if self.var_lst and km_dist not in self.var_lst and km_dist_sumw not in self.var_lst:
                 continue
             print(f"Loading: {km_dist}")
             # Remove processes that we don't include in the datacard


### PR DESCRIPTION
This PR addresses https://github.com/TopEFT/topcoffea/issues/27. Instead of altering how `histEFT` works, it is simpler to just have a separate histogram for storing the sum of the square of the weights. This will be part of the `new_histEFT` update, but I wanted a separate PR to make the review easier.