### PR TITLE
update ttgamma xsec with NLO k-factor

### DIFF
--- a/input_samples/sample_jsons/background_samples/central_UL/UL16APV_TTGamma_Dilept.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/UL16APV_TTGamma_Dilept.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 1.513,
+  "xsec": 2.2471,
   "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "TTGamma_centralUL16APV",

--- a/input_samples/sample_jsons/background_samples/central_UL/UL16APV_TTGamma_Dilept_NDSkim.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/UL16APV_TTGamma_Dilept_NDSkim.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 1.513,
+  "xsec": 2.2471,
   "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "TTGamma_centralUL16APV",

--- a/input_samples/sample_jsons/background_samples/central_UL/UL16APV_TTGamma_SingleLept.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/UL16APV_TTGamma_SingleLept.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 5.121,
+  "xsec": 7.6057,
   "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "TTGamma_centralUL16APV",

--- a/input_samples/sample_jsons/background_samples/central_UL/UL16APV_TTGamma_SingleLept_NDSkim.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/UL16APV_TTGamma_SingleLept_NDSkim.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 5.121,
+  "xsec": 7.6057,
   "year": "2016APV",
   "treeName": "Events",
   "histAxisName": "TTGamma_centralUL16APV",

--- a/input_samples/sample_jsons/background_samples/central_UL/UL16_TTGamma_Dilept.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/UL16_TTGamma_Dilept.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 1.513,
+  "xsec": 2.2471,
   "year": "2016",
   "treeName": "Events",
   "histAxisName": "TTGamma_centralUL16",

--- a/input_samples/sample_jsons/background_samples/central_UL/UL16_TTGamma_Dilept_NDSkim.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/UL16_TTGamma_Dilept_NDSkim.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 1.513,
+  "xsec": 2.2471,
   "year": "2016",
   "treeName": "Events",
   "histAxisName": "TTGamma_centralUL16",

--- a/input_samples/sample_jsons/background_samples/central_UL/UL16_TTGamma_SingleLept.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/UL16_TTGamma_SingleLept.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 5.121,
+  "xsec": 7.6057,
   "year": "2016",
   "treeName": "Events",
   "histAxisName": "TTGamma_centralUL16",

--- a/input_samples/sample_jsons/background_samples/central_UL/UL16_TTGamma_SingleLept_NDSkim.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/UL16_TTGamma_SingleLept_NDSkim.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 5.121,
+  "xsec": 7.6057,
   "year": "2016",
   "treeName": "Events",
   "histAxisName": "TTGamma_centralUL16",

--- a/input_samples/sample_jsons/background_samples/central_UL/UL17_TTGamma_Dilept.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/UL17_TTGamma_Dilept.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 1.513,
+  "xsec": 2.2471,
   "year": "2017",
   "treeName": "Events",
   "histAxisName": "TTGamma_centralUL17",

--- a/input_samples/sample_jsons/background_samples/central_UL/UL17_TTGamma_Dilept_NDSkim.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/UL17_TTGamma_Dilept_NDSkim.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 1.513,
+  "xsec": 2.2471,
   "year": "2017",
   "treeName": "Events",
   "histAxisName": "TTGamma_centralUL17",

--- a/input_samples/sample_jsons/background_samples/central_UL/UL17_TTGamma_SingleLept.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/UL17_TTGamma_SingleLept.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 5.121,
+  "xsec": 7.6057,
   "year": "2017",
   "treeName": "Events",
   "histAxisName": "TTGamma_centralUL17",

--- a/input_samples/sample_jsons/background_samples/central_UL/UL17_TTGamma_SingleLept_NDSkim.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/UL17_TTGamma_SingleLept_NDSkim.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 5.121,
+  "xsec": 7.6057,
   "year": "2017",
   "treeName": "Events",
   "histAxisName": "TTGamma_centralUL17",

--- a/input_samples/sample_jsons/background_samples/central_UL/UL18_TTGamma_Dilept.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/UL18_TTGamma_Dilept.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 1.513,
+  "xsec": 2.2471,
   "year": "2018",
   "treeName": "Events",
   "histAxisName": "TTGamma_centralUL18",

--- a/input_samples/sample_jsons/background_samples/central_UL/UL18_TTGamma_Dilept_NDSkim.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/UL18_TTGamma_Dilept_NDSkim.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 1.513,
+  "xsec": 2.2471,
   "year": "2018",
   "treeName": "Events",
   "histAxisName": "TTGamma_centralUL18",

--- a/input_samples/sample_jsons/background_samples/central_UL/UL18_TTGamma_SingleLept.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/UL18_TTGamma_SingleLept.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 5.121,
+  "xsec": 7.6057,
   "year": "2018",
   "treeName": "Events",
   "histAxisName": "TTGamma_centralUL18",

--- a/input_samples/sample_jsons/background_samples/central_UL/UL18_TTGamma_SingleLept_NDSkim.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/UL18_TTGamma_SingleLept_NDSkim.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 5.121,
+  "xsec": 7.6057,
   "year": "2018",
   "treeName": "Events",
   "histAxisName": "TTGamma_centralUL18",


### PR DESCRIPTION
This PR updates the xsec values of ttgamma (both dileptonic and semi-leptonic) samples by scaling the LO value by an NLO k-factor as done in TOP-21-004 analysis. 