### PR TITLE
Fix CI path to ROOT file using CERNBox

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Download root files
         run: |
-          wget --no-verbose http://www.crc.nd.edu/~kmohrman/files/root_files/for_ci/ttHJet_UL17_R1B14_NAOD-00000_10194_NDSkim.root
+          wget --no-verbose "http://www.crc.nd.edu/~kmohrman/files/root_files/for_ci/ttHJet_UL17_R1B14_NAOD-00000_10194_NDSkim.root"
 
       - name: Pytest setup
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Download root files
         run: |
-          wget --no-verbose http://www.crc.nd.edu/\~kmohrman/files/root_files/for_ci/ttHJet_UL17_R1B14_NAOD-00000_10194_NDSkim.root
+          wget --no-verbose --header="Host: www.crc.nd.edu" http://198.17.198.65/~kmohrman/files/root_files/for_ci/ttHJet_UL17_R1B14_NAOD-00000_10194_NDSkim.root
 
       - name: Pytest setup
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Download root files
         run: |
-          wget --no-verbose "http://www.crc.nd.edu/~kmohrman/files/root_files/for_ci/ttHJet_UL17_R1B14_NAOD-00000_10194_NDSkim.root"
+          wget --no-verbose http://www.crc.nd.edu/\~kmohrman/files/root_files/for_ci/ttHJet_UL17_R1B14_NAOD-00000_10194_NDSkim.root
 
       - name: Pytest setup
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Download root files
         run: |
-          wget --no-verbose --header="Host: www.crc.nd.edu" http://198.17.198.65/~kmohrman/files/root_files/for_ci/ttHJet_UL17_R1B14_NAOD-00000_10194_NDSkim.root
+          wget -o ttHJet_UL17_R1B14_NAOD-00000_10194_NDSkim.root https://cernbox.cern.ch/s/UxLNvr9BIXWqwpu/download
 
       - name: Pytest setup
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Download root files
         run: |
-          wget -o ttHJet_UL17_R1B14_NAOD-00000_10194_NDSkim.root https://cernbox.cern.ch/s/UxLNvr9BIXWqwpu/download
+          wget -O ttHJet_UL17_R1B14_NAOD-00000_10194_NDSkim.root https://cernbox.cern.ch/s/UxLNvr9BIXWqwpu/download
 
       - name: Pytest setup
         run: |


### PR DESCRIPTION
The CI runner started having DNS issues yesterday with the ROOT file we store at ND
```
run 
wget --no-verbose http://www.crc.nd.edu/~kmohrman/files/root_files/for_ci/ttHJet_UL17_R1B14_NAOD-00000_10194_NDSkim.root
wget: unable to resolve host address ‘ops.crc.nd.edu~kmohrman'
```

After some debugging I moved the file to my CERNBox and it now works.