### PR TITLE
Updates for EFT basis rotation

### DIFF
--- a/README_FITTING.md
+++ b/README_FITTING.md
@@ -15,5 +15,6 @@ python make_cards.py path/to/your.pkl.gz -C --do-nuisance --var-lst lj0pt ptz -d
 
 ## Running combine
 
-The next step is to run combine. This takes place inside of a CMSSW release, outside of `topcoffea`. See the [EFTFit](https://github.com/TopEFT/EFTFit) repo for instructions.
 :warning: The EFT basis rotation does not compile correctly on `glados`. Please make your workspace on a tested machine like `lxplus`. The root limit scans can still be done on `glados`.
+
+The next step is to run combine. This takes place inside of a CMSSW release, outside of `topcoffea`. See the [EFTFit](https://github.com/TopEFT/EFTFit) repo for instructions.

--- a/README_FITTING.md
+++ b/README_FITTING.md
@@ -15,4 +15,5 @@ python make_cards.py path/to/your.pkl.gz -C --do-nuisance --var-lst lj0pt ptz -d
 
 ## Running combine
 
- The next step is to run combine. This takes place inside of a CMSSW release, outside of `topcoffea`. See the [EFTFit](https://github.com/TopEFT/EFTFit) repo for instructions.
+The next step is to run combine. This takes place inside of a CMSSW release, outside of `topcoffea`. See the [EFTFit](https://github.com/TopEFT/EFTFit) repo for instructions.
+:warning: The EFT basis rotation does not compile correctly on `glados`. Please make your workspace on a tested machine like `lxplus`. The root limit scans can still be done on `glados`.

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -1138,6 +1138,12 @@ class DatacardMaker():
                 f.write("* autoMCStats 10\n")
             else:
                 f.write("* autoMCStats -1\n")
+
+        outf_json_name = self.FNAME_TEMPLATE.format(cat=ch,kmvar=km_dist,ext="json")
+        with open(os.path.join(self.out_dir,f"{outf_json_name}"),"w") as f:
+            print('making', os.path.join(self.out_dir,f"{outf_json_name}"))
+            json.dump(self.scalings_json, f, indent=4)
+
         dt = time.time() - tic
         print(f"File Write Time: {dt:.2f} s")
         print(f"Total Hists Written: {num_h}")

--- a/topeft/params/SMEFTsim-topU3l_dim6top.yml
+++ b/topeft/params/SMEFTsim-topU3l_dim6top.yml
@@ -2,21 +2,21 @@
 "CW": 0.88136 # PDG W / Z mass ratio 
 "SW": "np.sqrt(1 - np.square({CW}))" # eval in python
 
-# SMEFTsim j <-> dim6top q
-"ctj1": "ctq1"
-"cQj31": "cQq13"
-"ctj8": "ctq8"
-"cQj11": "cQq11"
-"cQj18": "cQq81"
-"cQj38": "cQq83"
+# dim6top q <-> SMEFTsim j
+"ctq1": "ctj1"
+"cQq13": "cQj31"
+"ctq8": "ctj8"
+"cQq11": "cQj11"
+"cQq81": "cQj18"
+"cQq83": "cQj38"
 
 "cQQ1": ["expr::SEMFTsim_cQQ1('0.5 * @0', {cQQ1})", ["cQQ1"]]
-"ctt": "ctt1"
+"ctt1": "ctt"
 
 # ctG relative minus sign
-"ctGRe": ["expr::ctGRe('-1 * @0', {ctG})", ["ctG"]]
-"ctGIm": ["expr::ctGIm('-1 * @0', {ctGI})", ["ctGI"]]
+"ctG":  ["expr::ctGRe('-1 * @0', {ctG})", ["ctG"]]
+"ctGI": ["expr::ctGIm('-1 * @0', {ctGI})", ["ctGI"]]
 
 # ctW,ctB <-> ctW,ctZ
-"ctWRe": ["expr::ctWRe('-1 * @0', {ctW})", ["ctW"]]
-"ctBRe": ["expr::ctBRe('@0 / {SW} - @1 * {CW}/{SW} ', {ctZ}, {ctW})", ["ctZ", "ctW"]] # {ctZ}/SW - {ctW}/TW (TW = tan Weinberg angle)
+"ctW": ["expr::ctW('-1 * @0', {ctWRe})", ["ctWRe"]]
+"ctZ": ["expr::ctZ('@0 * {SW} - @1 * {CW}', {ctBRe}, {ctWRe})", ["ctBRe", "ctWRe"]] # {ctBRe}*SW - {ctWRe}*CW


### PR DESCRIPTION
This PR updates the basis rotations so that the SMEFTsim WC names become the POIs and any dim6top names are only used internally. There is also a caveat added to the fitting README about `glados` having issues making a workspace with `expr` in `scalings.json`. It works fine on `lxplus`, and the resulting root file can be used on `glados.

Here's an example of an (incomplete) 2D scan of `ctBRe` vs `ctWRe` (rotating `ctZ` and `ctW`). The correlations are much smaller than in TOP-22-006 when using `dim6top`.
<img width="696" height="472" alt="image" src="https://github.com/user-attachments/assets/77509716-a1da-4571-a2c7-dc81479d6597" />