### PR TITLE
Run-3 tau_h channels, CR/SR metadata, and zero-yield audit updates

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -97,7 +97,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         return base_hist_names_ordered, expanded_hist_names_ordered
 
-    def __init__(self, samples, wc_names_lst=[], hist_lst=None, ecut_threshold=None, fill_sumw2_hist=True, do_systematics=False, split_by_lepton_flavor=False, skip_signal_regions=False, skip_control_regions=False, muonSyst='nominal', dtype=np.float32, rebin=False, offZ_split=False, tau_h_analysis=False, fwd_analysis=False, useRun3MVA=True, tau_run_mode="standard"):
+    def __init__(self, samples, wc_names_lst=[], hist_lst=None, ecut_threshold=None, fill_sumw2_hist=True, do_systematics=False, split_by_lepton_flavor=False, skip_signal_regions=False, skip_control_regions=False, muonSyst='nominal', dtype=np.float32, rebin=False, offZ_split=False, tau_h_analysis=False, fwd_analysis=False, all_analysis=False, useRun3MVA=True, tau_run_mode="standard"):
 
         self._samples = samples
         self._wc_names_lst = wc_names_lst
@@ -105,6 +105,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         self.offZ_3l_split = offZ_split
         self.tau_h_analysis = tau_h_analysis
         self.fwd_analysis = fwd_analysis
+        self.all_analysis = all_analysis
         self.useRun3MVA = useRun3MVA #can be switched to False use the alternative cuts
         self.tau_run_mode = tau_run_mode
         # self._tau_wp_checked = False

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -284,10 +284,6 @@ class AnalysisProcessor(processor.ProcessorABC):
         xsec               = self._samples[dataset]["xsec"]
         sow                = self._samples[dataset]["nSumOfWeights"]
 
-        print("\n\n\n\n\n")
-        print("histAxisName:", histAxisName)
-        print("\n\n\n\n\n")
-
         is_run3 = False
         if year.startswith("202"):
             is_run3 = True

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -499,8 +499,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         ################### Tau selection ####################
 
         if self.tau_h_analysis:
-            tau_fo_tag = "VLoose" #if is_run2 else "Loose"
-            tau_T_tag = "Loose" #if is_run2 else "Medium"
+            tau_fo_tag = "VLoose" if is_run2 else "Loose"
+            tau_T_tag = "Loose" if is_run2 else "Medium"
 
             if is_run2:
                 vs_jet = tau.idDeepTau2017v2p1VSjet
@@ -614,15 +614,15 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             if not isData:
                 AttachTauSF(events, tau_T, year=year, vsJetWP=tau_T_tag)
-                print("\n\n\n\n\n\n")
-                print("taus[pt]", ak.to_list(tau_T.pt))
-                print("taus[isLoose]", ak.to_list(tau_T.isLoose))
-                print("taus[isMedium]", ak.to_list(tau_T.isMedium))
-                print("taus[sf_tau_real]", ak.to_list(tau_T.sf_tau_real))
-                print("taus[sf_tau_fake]", ak.to_list(tau_T.sf_tau_real))
-                print("events[sf_2l_taus_real]", ak.to_list(events["sf_2l_taus_real"]))
-                print("events[sf_2l_taus_fake]", ak.to_list(events["sf_2l_taus_fake"]))
-                print("\n\n\n\n\n\n")
+                # print("\n\n\n\n\n\n")
+                # print("taus[pt]", ak.to_list(tau_T.pt))
+                # print("taus[isLoose]", ak.to_list(tau_T.isLoose))
+                # print("taus[isMedium]", ak.to_list(tau_T.isMedium))
+                # print("taus[sf_tau_real]", ak.to_list(tau_T.sf_tau_real))
+                # print("taus[sf_tau_fake]", ak.to_list(tau_T.sf_tau_fake))
+                # print("events[sf_2l_taus_real]", ak.to_list(events["sf_2l_taus_real"]))
+                # print("events[sf_2l_taus_fake]", ak.to_list(events["sf_2l_taus_fake"]))
+                # print("\n\n\n\n\n\n")
 
         else:
             if is_run2:

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -511,7 +511,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 vs_e = tau.idDeepTau2018v2p5VSe
                 vs_mu = tau.idDeepTau2018v2p5VSmu
 
-            tau["pt"], tau["mass"] = ApplyTES(year, tau, isData, "Medium") #tau_T_tag)
+            tau["pt"], tau["mass"] = ApplyTES(year, tau, isData, tau_T_tag)
 
             tau["isVLoose"] = tauSelection.isVLooseTau(vs_jet)
             tau["isLoose"] = tauSelection.isLooseTau(vs_jet)
@@ -613,7 +613,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             )
 
             if not isData:
-                AttachTauSF(events, tau_T, year=year, vsJetWP="Medium")
+                AttachTauSF(events, tau_T, year=year, vsJetWP=tau_T_tag)
                 print("\n\n\n\n\n\n")
                 print("taus[pt]", ak.to_list(tau_T.pt))
                 print("taus[isLoose]", ak.to_list(tau_T.isLoose))

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -601,7 +601,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 raise ValueError(f"Unknown tau_run_mode '{self.tau_run_mode}'")
             no_tau_mask = (nLtau == 0)
 
-            tau0 = ak.where(tau_L_mask, tau0_T, tau0_fo)
+            tau0 = tau0_T
 
             _log_tau_flag_counts(
                 "tau_h_event_masks",
@@ -780,8 +780,8 @@ class AnalysisProcessor(processor.ProcessorABC):
             if not isData:
                 cleanedJets["pt_gen"] = ak.values_astype(ak.fill_none(cleanedJets.matched_gen.pt, 0), np.float32)
                 if self.tau_h_analysis:
-                    tau["pt"], tau["mass"]      = ApplyTESSystematic(year, tau, isData, syst_var)
-                    tau["pt"], tau["mass"]      = ApplyFESSystematic(year, tau, isData, syst_var)
+                    tau["pt"], tau["mass"]      = ApplyTESSystematic(year, tau, isData, syst_var, tau_T_tag)
+                    tau["pt"], tau["mass"]      = ApplyFESSystematic(year, tau, isData, syst_var, tau_T_tag)
 
             events_cache = events.caches[0]
             cleanedJets = ApplyJetCorrections(year, corr_type='jets', isData=isData, era=run_era).build(cleanedJets, lazy_cache=events_cache)  #Run3 ready
@@ -1431,7 +1431,8 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             if self.tau_h_analysis:
                 varnames["ptz_wtau"] = ptz_wtau
-                varnames["tau0pt"] = tau0.pt
+                varnames["tau0Tpt"] = tau0_T.pt
+                varnames["tau0Fpt"] = tau0_fo.pt
                 pass
 
             for varname, var in varnames.items():

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -284,6 +284,10 @@ class AnalysisProcessor(processor.ProcessorABC):
         xsec               = self._samples[dataset]["xsec"]
         sow                = self._samples[dataset]["nSumOfWeights"]
 
+        print("\n\n\n\n\n")
+        print("histAxisName:", histAxisName)
+        print("\n\n\n\n\n")
+
         is_run3 = False
         if year.startswith("202"):
             is_run3 = True
@@ -593,19 +597,13 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             if not isData:
                 AttachTauSF(events, tau_loose, year=year, vsJetWP="Loose")
-
-            # if (not self._tau_wp_checked) and len(events) > 0:
-            #     n_tau_vloose = int(ak.sum(tau_F_mask))
-            #     n_tau_loose = int(ak.sum(tau_L_mask))
-            #     n_tau_vloose_only = int(ak.sum(tau_F_mask & ~tau_L_mask))
-            #     print(
-            #         f"\n\n\n\n\n\n\n\n\n[Tau WP check - {self.tau_run_mode}] Events with >=1 VLoose tau: {ak.to_list(n_tau_vloose)};\n>=1 Loose tau: {ak.to_list(n_tau_loose)};\nVLoose-only: {ak.to_list(n_tau_vloose_only)}\n\n\n\n\n\n\n\n\n"
-            #     )
-            #     if self.tau_run_mode == "standard":
-            #         masks_identical = bool(ak.all(tau_F_mask == tau_L_mask)) if len(events) > 0 else False
-            #         if masks_identical and (n_tau_vloose > 0 or n_tau_loose > 0):
-            #             raise AssertionError("Ftau and Ttau masks are identical; check tau WP separation")
-            #     self._tau_wp_checked = True
+                print("\n\n\n\n\n\n")
+                print("taus[pt]", ak.to_list(tau_loose.pt))
+                print("taus[sf_tau_real]", ak.to_list(tau_loose.sf_tau_real))
+                print("taus[sf_tau_fake]", ak.to_list(tau_loose.sf_tau_real))
+                print("events[sf_2l_taus_real]", ak.to_list(events["sf_2l_taus_real"]))
+                print("events[sf_2l_taus_fake]", ak.to_list(events["sf_2l_taus_fake"]))
+                print("\n\n\n\n\n\n")
 
         else:
             if is_run2:

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -499,7 +499,9 @@ class AnalysisProcessor(processor.ProcessorABC):
         ################### Tau selection ####################
 
         if self.tau_h_analysis:
-            tau["pt"], tau["mass"] = ApplyTES(year, tau, isData)
+            tau_fo_tag = "VLoose" #if is_run2 else "Loose"
+            tau_T_tag = "Loose" #if is_run2 else "Medium"
+
             if is_run2:
                 vs_jet = tau.idDeepTau2017v2p1VSjet
                 vs_e = tau.idDeepTau2017v2p1VSe
@@ -509,8 +511,11 @@ class AnalysisProcessor(processor.ProcessorABC):
                 vs_e = tau.idDeepTau2018v2p5VSe
                 vs_mu = tau.idDeepTau2018v2p5VSmu
 
+            tau["pt"], tau["mass"] = ApplyTES(year, tau, isData, "Medium") #tau_T_tag)
+
             tau["isVLoose"] = tauSelection.isVLooseTau(vs_jet)
             tau["isLoose"] = tauSelection.isLooseTau(vs_jet)
+            tau["isMedium"] = tauSelection.isMediumTau(vs_jet)
             tau["iseTight"] = tauSelection.iseTightTau(vs_e)
             tau["ismTight"] = ak.values_astype(tauSelection.ismTightTau(vs_mu), np.int8)
             tau["isPresVLoose"] = tauSelection.isPresTau(
@@ -535,7 +540,19 @@ class AnalysisProcessor(processor.ProcessorABC):
                 minpt=20,
                 vsJetWP="Loose",
             )
-            tau["isPres"] = tau["isPresVLoose"]
+            tau["isPresMedium"] = tauSelection.isPresTau(
+                tau.pt,
+                tau.eta,
+                tau.dxy,
+                tau.dz,
+                vs_jet,
+                vs_e,
+                vs_mu,
+                minpt=20,
+                vsJetWP="Medium",
+            )
+
+            tau["isPres"] = tau[f"isPres{tau_fo_tag}"]
 
             tau["isClean"] = te_os.isClean(tau, l_fo, drmin=0.3)
             tau["isGood"]  =  tau["isClean"] & tau["isPres"]
@@ -563,28 +580,28 @@ class AnalysisProcessor(processor.ProcessorABC):
             )
             tau = tau[tau['DMflag']]
 
-            tau_vloose = tau
-            tau_vloose_padded = ak.pad_none(tau_vloose, 1)
-            tau0_vloose = tau_vloose_padded[:,0]
+            tau_fo = tau
+            tau_fo_padded = ak.pad_none(tau_fo, 1)
+            tau0_fo = tau_fo_padded[:,0]
 
-            tau_loose = tau_vloose[tau_vloose["isLoose"]>0]
-            tau_loose_padded = ak.pad_none(tau_loose, 1)
-            tau0_loose = tau_loose_padded[:,0]
+            tau_T = tau_fo[tau_fo["isLoose"]>0]
+            tau_T_padded = ak.pad_none(tau_T, 1)
+            tau0_T = tau_T_padded[:,0]
 
-            cleaning_taus = tau_loose
-            nLtau  = ak.num(tau_loose)
+            cleaning_taus = tau_T
+            nLtau  = ak.num(tau_T)
 
             if self.tau_run_mode == "standard":
-                tau_F_mask = (ak.num(tau_vloose) == 1)
+                tau_F_mask = (ak.num(tau_fo) == 1)
                 tau_L_mask = (nLtau == 1)
             elif self.tau_run_mode == "taufitter":
-                tau_F_mask = (ak.num(tau_vloose) >= 1)
+                tau_F_mask = (ak.num(tau_fo) >= 1)
                 tau_L_mask = (nLtau >= 1)
             else:
                 raise ValueError(f"Unknown tau_run_mode '{self.tau_run_mode}'")
             no_tau_mask = (nLtau == 0)
 
-            tau0 = ak.where(tau_L_mask, tau0_loose, tau0_vloose)
+            tau0 = ak.where(tau_L_mask, tau0_T, tau0_fo)
 
             _log_tau_flag_counts(
                 "tau_h_event_masks",
@@ -596,11 +613,13 @@ class AnalysisProcessor(processor.ProcessorABC):
             )
 
             if not isData:
-                AttachTauSF(events, tau_loose, year=year, vsJetWP="Loose")
+                AttachTauSF(events, tau_T, year=year, vsJetWP="Medium")
                 print("\n\n\n\n\n\n")
-                print("taus[pt]", ak.to_list(tau_loose.pt))
-                print("taus[sf_tau_real]", ak.to_list(tau_loose.sf_tau_real))
-                print("taus[sf_tau_fake]", ak.to_list(tau_loose.sf_tau_real))
+                print("taus[pt]", ak.to_list(tau_T.pt))
+                print("taus[isLoose]", ak.to_list(tau_T.isLoose))
+                print("taus[isMedium]", ak.to_list(tau_T.isMedium))
+                print("taus[sf_tau_real]", ak.to_list(tau_T.sf_tau_real))
+                print("taus[sf_tau_fake]", ak.to_list(tau_T.sf_tau_real))
                 print("events[sf_2l_taus_real]", ak.to_list(events["sf_2l_taus_real"]))
                 print("events[sf_2l_taus_fake]", ak.to_list(events["sf_2l_taus_fake"]))
                 print("\n\n\n\n\n\n")

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -949,7 +949,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 select_cat_dict = json.load(ch_json_test)
 
             if not self._skip_signal_regions:
-            # If we are not skipping the signal regions, we will import the SR categories
+                # If we are not skipping the signal regions, we will import the SR categories
                 # This dictionary keeps track of which selections go with which SR categories
                 if self.offZ_3l_split:
                     import_sr_cat_dict = select_cat_dict["OFFZ_SPLIT_CH_LST_SR"]
@@ -957,15 +957,19 @@ class AnalysisProcessor(processor.ProcessorABC):
                     import_sr_cat_dict = select_cat_dict["TAU_CH_LST_SR"]
                 elif self.fwd_analysis:
                     import_sr_cat_dict = select_cat_dict["FWD_CH_LST_SR"]
+                elif self.all_analysis:
+                    import_sr_cat_dict = select_cat_dict["ALL_CH_LST_SR"]
                 else:
                     import_sr_cat_dict = select_cat_dict["TOP22_006_CH_LST_SR"]
 
             if not self._skip_control_regions:
-            # If we are not skipping the control regions, we will import the CR categories
+                # If we are not skipping the control regions, we will import the CR categories
                 # This dictionary keeps track of which selections go with which CR categories
-                import_cr_cat_dict = select_cat_dict["CH_LST_CR"]
-                if self.tau_h_analysis:
-                    import_cr_cat_dict.update(select_cat_dict["TAU_CH_LST_CR"])
+                if self.tau_h_analysis or self.all_analysis:
+                    import_cr_cat_dict = select_cat_dict["TAU_CH_LST_CR"]
+                else:
+                    import_cr_cat_dict = select_cat_dict["CH_LST_CR"]
+ 
 
             #This list keeps track of the lepton categories
             lep_cats = []

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -423,6 +423,45 @@ def _resolve_process_axis_labels(histogram):
         return tuple(axis)
 
 
+def _resolve_grouped_processes(group_map):
+    """Return the ordered tuple of process names covered by *group_map*."""
+
+    grouped = []
+    seen = set()
+    for members in (group_map or {}).values():
+        for name in members or ():
+            if name in seen:
+                continue
+            seen.add(name)
+            grouped.append(name)
+    return tuple(grouped)
+
+
+def _filter_process_axis(histogram, allowed_processes):
+    """Return *histogram* with any process not in *allowed_processes* removed."""
+
+    if histogram is None or not _has_axis(histogram, "process"):
+        return histogram
+
+    allowed_set = set(allowed_processes or ())
+    axis_labels = _resolve_process_axis_labels(histogram)
+    if not axis_labels:
+        return histogram
+
+    if allowed_set:
+        to_remove = [proc for proc in axis_labels if proc not in allowed_set]
+    else:
+        to_remove = list(axis_labels)
+
+    if not to_remove:
+        return histogram
+
+    try:
+        return histogram.remove("process", to_remove)
+    except Exception:
+        return histogram
+
+
 def _has_axis(histogram, axis_name):
     """Return ``True`` when *histogram* exposes *axis_name* as an axis."""
 
@@ -832,8 +871,17 @@ def _summarize_zero_yield_processes(
     *,
     region_name,
     preserve_njets_bins=False,
+    region_ctx=None,
+    variables=None,
 ):
     """Return a structured summary of zero-yield processes per channel."""
+
+    if region_ctx is not None:
+        return _summarize_zero_yield_processes_by_variable(
+            dict_of_hists,
+            region_ctx=region_ctx,
+            variables=variables,
+        )
 
     summary = {
         "region": region_name,
@@ -927,6 +975,154 @@ def _summarize_zero_yield_processes(
     return summary
 
 
+def _summarize_zero_yield_processes_by_variable(
+    dict_of_hists,
+    *,
+    region_ctx,
+    variables=None,
+):
+    """Return a structured summary of zero-yield processes per channel and variable."""
+
+    summary = {
+        "region": region_ctx.name,
+        "channels_scanned": 0,
+        "channel_entries": [],
+        "zero_process_total": 0,
+        "data_driven_zero_total": 0,
+        "missing_data_driven_prefixes": set(),
+        "errors": [],
+    }
+
+    variables_to_scan = _resolve_requested_variables(
+        dict_of_hists, variables, context="zero-yield scan"
+    )
+
+    prepared_cache = {}
+    missing_data_driven = {}
+    for matcher in DATA_DRIVEN_MATCHERS:
+        missing_data_driven[_describe_data_driven_matcher(matcher)] = False
+
+    for var_name in variables_to_scan:
+        if "sumw2" in var_name:
+            continue
+        if var_name in region_ctx.skip_variables:
+            continue
+
+        variable_metadata = _prepare_variable_payload(
+            var_name,
+            region_ctx,
+            metadata_only=True,
+            prepared_cache=prepared_cache,
+        )
+        if not variable_metadata:
+            prepared_cache.setdefault(var_name, None)
+            continue
+
+        histo = dict_of_hists.get(var_name)
+        if histo is None:
+            continue
+
+        channel_transformations = variable_metadata["channel_transformations"]
+        available_channels = set(variable_metadata.get("available_channels") or ())
+        available_processes = tuple(_resolve_process_axis_labels(histo))
+
+        if not _has_axis(histo, "process"):
+            summary["errors"].append(
+                f"No process axis available for zero-yield scan in variable '{var_name}'."
+            )
+            continue
+
+        allowed_processes = _resolve_grouped_processes(region_ctx.group_map)
+        if allowed_processes:
+            available_processes = tuple(
+                proc for proc in available_processes if proc in allowed_processes
+            )
+        else:
+            available_processes = ()
+
+        if not available_channels:
+            summary["errors"].append(
+                f"No channel axis labels available for zero-yield scan in variable '{var_name}'."
+            )
+            continue
+
+        if not available_processes:
+            summary["errors"].append(
+                f"No grouped process labels available for zero-yield scan in variable '{var_name}'."
+            )
+            continue
+
+        for matcher in DATA_DRIVEN_MATCHERS:
+            label = _describe_data_driven_matcher(matcher)
+            if not missing_data_driven.get(label):
+                missing_data_driven[label] = any(
+                    matcher.search(proc) for proc in available_processes
+                )
+
+        for chan_label, chan_bins in region_ctx.channel_map.items():
+            summary["channels_scanned"] += 1
+            unique_bins = tuple(dict.fromkeys(chan_bins))
+            selected_bins = []
+            missing_bins = []
+            for bin_name in unique_bins:
+                transformed = _apply_channel_transforms(
+                    bin_name, channel_transformations
+                )
+                if transformed in available_channels:
+                    selected_bins.append(transformed)
+                else:
+                    missing_bins.append(bin_name)
+
+            if not selected_bins:
+                summary["channel_entries"].append(
+                    {
+                        "label": chan_label,
+                        "variable": var_name,
+                        "missing_bins": tuple(missing_bins),
+                        "zero_processes": [],
+                    }
+                )
+                continue
+
+            selected_bins = list(dict.fromkeys(selected_bins))
+
+            zero_processes = []
+            for proc in available_processes:
+                try:
+                    proc_hist = histo.integrate("process", [proc])
+                    proc_hist = proc_hist.integrate("channel", selected_bins)
+                except Exception:
+                    continue
+
+                proc_hist = _integrate_nominal_axis(proc_hist)
+
+                if not _hist_has_content(proc_hist):
+                    is_data_driven = any(
+                        matcher.search(proc) for matcher in DATA_DRIVEN_MATCHERS
+                    )
+                    zero_processes.append((proc, is_data_driven))
+
+            if zero_processes or missing_bins:
+                summary["channel_entries"].append(
+                    {
+                        "label": chan_label,
+                        "variable": var_name,
+                        "missing_bins": tuple(missing_bins),
+                        "zero_processes": zero_processes,
+                    }
+                )
+                summary["zero_process_total"] += len(zero_processes)
+                summary["data_driven_zero_total"] += sum(
+                    1 for _, is_data_driven in zero_processes if is_data_driven
+                )
+
+    for pattern_label, seen in missing_data_driven.items():
+        if not seen:
+            summary["missing_data_driven_prefixes"].add(pattern_label)
+
+    return summary
+
+
 def _emit_zero_yield_summary(summary, *, detailed=False):
     """Print a short or detailed zero-yield report for the supplied *summary*."""
 
@@ -941,6 +1137,10 @@ def _emit_zero_yield_summary(summary, *, detailed=False):
     if detailed:
         print("\nZero-yield content summary:")
         for entry in flagged_channels:
+            entry_label = entry.get("label", "<unknown>")
+            variable = entry.get("variable")
+            if variable:
+                entry_label = f"{entry_label} [{variable}]"
             issues = []
             if entry.get("missing_bins"):
                 issues.append(
@@ -955,7 +1155,7 @@ def _emit_zero_yield_summary(summary, *, detailed=False):
                     zero_labels.append(label)
                 issues.append("zero-content processes: " + ", ".join(zero_labels))
             if issues:
-                print(f"  - {region_label}::{entry['label']}: " + "; ".join(issues))
+                print(f"  - {region_label}::{entry_label}: " + "; ".join(issues))
 
         if missing_data_driven:
             print(
@@ -1746,6 +1946,14 @@ def _prepare_variable_payload(
                 "process", region_ctx.signal_samples
             )
 
+    allowed_processes = _resolve_grouped_processes(region_ctx.group_map)
+    hist_mc = _filter_process_axis(hist_mc, allowed_processes)
+    hist_data = _filter_process_axis(hist_data, allowed_processes)
+    if hist_mc_sumw2_orig is not None:
+        hist_mc_sumw2_orig = _filter_process_axis(
+            hist_mc_sumw2_orig, allowed_processes
+        )
+
     if region_ctx.debug_channel_lists and verbose:
         try:
             channels_lst = yt.get_cat_lables(histo, "channel")
@@ -2009,23 +2217,23 @@ def _render_variable_category(
             hist_data_nominal = hist_data_integrated[{"process": sum}].integrate(
                 "systematic", "nominal"
             )
-            if not _hist_has_content(hist_mc_nominal):
+            hist_data_like = (
+                hist_data_nominal
+                if (unblind_flag or not region_ctx.use_mc_as_data_when_blinded)
+                else hist_mc_nominal
+            )
+            has_mc = _hist_has_content(hist_mc_nominal)
+            has_data_like = _hist_has_content(hist_data_like)
+            if not has_mc and not has_data_like:
                 logger.warning(
-                    "Empty histogram for hist_cat=%s var_name=%s, skipping 2D plot.",
-                    hist_cat,
-                    var_name,
-                )
-                return 0, 0, html_dirs
-            if not _hist_has_content(hist_data_nominal):
-                logger.warning(
-                    "Empty data histogram for hist_cat=%s var_name=%s, skipping 2D plot.",
+                    "Empty data-like and MC histogram for hist_cat=%s var_name=%s, skipping 2D plot.",
                     hist_cat,
                     var_name,
                 )
                 return 0, 0, html_dirs
             fig = make_sparse2d_fig(
                 hist_mc_nominal,
-                hist_data_nominal,
+                hist_data_like,
                 var_name,
                 channel_name=hist_cat,
                 lumitag=region_ctx.lumi_pair[0],
@@ -2043,16 +2251,16 @@ def _render_variable_category(
             hist_data_integrated = hist_data_integrated.integrate(
                 "systematic", "nominal"
             )
-            if not _hist_has_content(hist_mc_integrated):
+            hist_data_like = (
+                hist_data_integrated
+                if (unblind_flag or not region_ctx.use_mc_as_data_when_blinded)
+                else hist_mc_integrated
+            )
+            has_mc = _hist_has_content(hist_mc_integrated)
+            has_data_like = _hist_has_content(hist_data_like)
+            if not has_mc and not has_data_like:
                 logger.warning(
-                    "Empty histogram for hist_cat=%s var_name=%s, skipping plot.",
-                    hist_cat,
-                    var_name,
-                )
-                return 0, 0, html_dirs
-            if not _hist_has_content(hist_data_integrated):
-                logger.warning(
-                    "Empty data histogram for hist_cat=%s var_name=%s, skipping plot.",
+                    "Empty data-like and MC histogram for hist_cat=%s var_name=%s, skipping plot.",
                     hist_cat,
                     var_name,
                 )
@@ -2076,7 +2284,7 @@ def _render_variable_category(
                 stacked_kwargs["bins"] = bins_override
             fig = make_region_stacked_ratio_fig(
                 hist_mc_integrated,
-                hist_data_integrated,
+                hist_data_like,
                 unit_norm_bool,
                 var=var_name,
                 group=group,
@@ -2361,7 +2569,7 @@ def validate_channel_group(histos, expected_labels, transformations, region, sub
 
 def populate_group_map(samples, pattern_map):
     out = OrderedDict((k, []) for k in pattern_map)
-    fallback_groups = OrderedDict()
+    unmatched = []
 
     for proc_name in samples:
         canonical_name = tc_utils.canonicalize_process_name(proc_name)
@@ -2375,17 +2583,14 @@ def populate_group_map(samples, pattern_map):
             if matched:
                 break
         if not matched:
-            if proc_name not in fallback_groups:
-                logger.warning(
-                    "Process name '%s' does not match any configured group pattern; "
-                    "assigning it to fallback group '%s'.",
-                    proc_name,
-                    proc_name,
-                )
-                fallback_groups[proc_name] = []
-            fallback_groups[proc_name].append(proc_name)
+            unmatched.append(proc_name)
 
-    out.update(fallback_groups)
+    if unmatched:
+        logger.warning(
+            "Process names did not match any configured group pattern; skipping: %s",
+            ", ".join(sorted(unmatched)),
+        )
+
     return out
 
 
@@ -4158,9 +4363,7 @@ def build_region_context(
         region_upper, region_plot_cfg.get("stacked_ratio_style")
     )
 
-    skip_variables = (
-        set(region_plot_cfg.get("skip_variables", [])) if enable_category_skips else set()
-    )
+    skip_variables = set(region_plot_cfg.get("skip_variables", []))
     analysis_bins = {}
     for var_name, spec in region_plot_cfg.get("analysis_bins", {}).items():
         if isinstance(spec, str):
@@ -6039,6 +6242,7 @@ def run_plots_for_region(
         dict_of_hists, reference_channel_map=CHANNEL_REFERENCE_MAP
     )
     restored_channel_labels = False
+    summary_region_ctx = None
 
     if not split_channels_available and "per-channel" in requested_channel_modes:
         restored_channel_labels = yt.restore_split_channel_labels(
@@ -6064,6 +6268,8 @@ def run_plots_for_region(
             preserve_njets_bins=preserve_njets_bins,
             enable_category_skips=enable_category_skips,
         )
+        if summary_region_ctx is None:
+            summary_region_ctx = region_ctx
 
         if region_ctx.channel_mode == "per-channel" and not split_channels_available:
             mode_label = CHANNEL_MODE_LABELS.get(channel_mode, channel_mode)
@@ -6096,6 +6302,8 @@ def run_plots_for_region(
         dict_of_hists,
         region_name=region_name,
         preserve_njets_bins=preserve_njets_bins,
+        region_ctx=summary_region_ctx,
+        variables=variables,
     )
     _emit_zero_yield_summary(
         zero_yield_summary,

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -884,7 +884,7 @@ if __name__ == "__main__":
             # use mid-range compression for chunks results.
             # Valid values are 0 (minimum compression, less memory
             # usage) to 16 (maximum compression, more memory usage).
-            "compression": 8,
+            "compression": 9,
             # automatically find an adequate resource allocation for tasks.
             # tasks are first tried using the maximum resources seen of previously ran
             # tasks. on resource exhaustion, they are retried with the maximum resource
@@ -910,7 +910,9 @@ if __name__ == "__main__":
             # 'disk': 8000,   #MB
             # 'memory': 10000, #MB
             # control the size of accumulation tasks.
-            "treereduction": 10,
+            # "treereduction": 10,
+            'chunks_per_accum': 25,
+            'chunks_accum_in_mem': 2,
             # terminate workers on which tasks have been running longer than average.
             # This is useful for temporary conditions on worker nodes where a task will
             # be finish faster is ran in another worker.

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -170,7 +170,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--chunksize",
         "-s",
-        default=100000,
+        default=50000,
         help="Number of events per chunk",
     )
     parser.add_argument(
@@ -296,7 +296,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--wq-filepath",
-        default=None,
+        default="/tmp/${USER}-workers",
         help=(
             "Override the Work Queue staging directory (default: /tmp/${USER}-workers). The path will be "
             "created if missing; if creation fails a system temporary directory will be used instead."
@@ -453,7 +453,7 @@ if __name__ == "__main__":
     if dotest:
         if executor_name == "futures":
             nchunks = 2
-            chunksize = 10000
+            chunksize = 100
             nworkers = 1
             print(
                 "Running a fast test with %i workers, %i chunks of %i events"
@@ -490,26 +490,26 @@ if __name__ == "__main__":
             hist_lst.append("tau0Fpt")
         if fwd_analysis:
             hist_lst.append("lt")
-        if "lepton_pt_vs_eta" not in hist_lst:
-            hist_lst.append("lepton_pt_vs_eta")
-        if "l0_SeedEtaOrX_vs_SeedPhiOrY" not in hist_lst:
-            hist_lst.append("l0_SeedEtaOrX_vs_SeedPhiOrY")
-        if "l0_eta_vs_phi" not in hist_lst:
-            hist_lst.append("l0_eta_vs_phi")
-        if "l1_SeedEtaOrX_vs_SeedPhiOrY" not in hist_lst:
-            hist_lst.append("l1_SeedEtaOrX_vs_SeedPhiOrY")
-        if "l1_eta_vs_phi" not in hist_lst:
-            hist_lst.append("l1_eta_vs_phi")
-        if fill_sumw2 and "lepton_pt_vs_eta_sumw2" not in hist_lst:
-            hist_lst.append("lepton_pt_vs_eta_sumw2")
-        if fill_sumw2 and "l0_SeedEtaOrX_vs_SeedPhiOrY_sumw2" not in hist_lst:
-            hist_lst.append("l0_SeedEtaOrX_vs_SeedPhiOrY_sumw2")
-        if fill_sumw2 and "l0_eta_vs_phi_sumw2" not in hist_lst:
-            hist_lst.append("l0_eta_vs_phi_sumw2")
-        if fill_sumw2 and "l1_SeedEtaOrX_vs_SeedPhiOrY_sumw2" not in hist_lst:
-            hist_lst.append("l1_SeedEtaOrX_vs_SeedPhiOrY_sumw2")
-        if fill_sumw2 and "l1_eta_vs_phi_sumw2" not in hist_lst:
-            hist_lst.append("l1_eta_vs_phi_sumw2")
+        # if "lepton_pt_vs_eta" not in hist_lst:
+        #     hist_lst.append("lepton_pt_vs_eta")
+        # if "l0_SeedEtaOrX_vs_SeedPhiOrY" not in hist_lst:
+        #     hist_lst.append("l0_SeedEtaOrX_vs_SeedPhiOrY")
+        # if "l0_eta_vs_phi" not in hist_lst:
+        #     hist_lst.append("l0_eta_vs_phi")
+        # if "l1_SeedEtaOrX_vs_SeedPhiOrY" not in hist_lst:
+        #     hist_lst.append("l1_SeedEtaOrX_vs_SeedPhiOrY")
+        # if "l1_eta_vs_phi" not in hist_lst:
+        #     hist_lst.append("l1_eta_vs_phi")
+        # if fill_sumw2 and "lepton_pt_vs_eta_sumw2" not in hist_lst:
+        #     hist_lst.append("lepton_pt_vs_eta_sumw2")
+        # if fill_sumw2 and "l0_SeedEtaOrX_vs_SeedPhiOrY_sumw2" not in hist_lst:
+        #     hist_lst.append("l0_SeedEtaOrX_vs_SeedPhiOrY_sumw2")
+        # if fill_sumw2 and "l0_eta_vs_phi_sumw2" not in hist_lst:
+        #     hist_lst.append("l0_eta_vs_phi_sumw2")
+        # if fill_sumw2 and "l1_SeedEtaOrX_vs_SeedPhiOrY_sumw2" not in hist_lst:
+        #     hist_lst.append("l1_SeedEtaOrX_vs_SeedPhiOrY_sumw2")
+        # if fill_sumw2 and "l1_eta_vs_phi_sumw2" not in hist_lst:
+        #     hist_lst.append("l1_eta_vs_phi_sumw2")
     elif args.hist_list == ["cr"]:
         # Here we hardcode a list of hists used for the CRs
         hist_lst = [
@@ -682,10 +682,8 @@ if __name__ == "__main__":
             requested_years.update(year_synonyms.get(year_str, {year_str}))
 
     print(">> Loaded a total of %i samples from json files." % len(samplesdict))
-    print("requested_years:", requested_years)
 
     if requested_years is not None:
-        print([sample.get("year") for sample in samplesdict.values()])
         samplesdict = {
             name: sample
             for name, sample in samplesdict.items()

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -606,7 +606,7 @@ if __name__ == "__main__":
         # Open cfg files
         else:
             with open(f) as fin:
-                print(" >> Reading json from cfg file...")
+                print(" >> Reading json from cfg file...", f)
                 lines = fin.readlines()
                 for l in lines:
                     if "#" in l:
@@ -679,7 +679,11 @@ if __name__ == "__main__":
 
             requested_years.update(year_synonyms.get(year_str, {year_str}))
 
+    print(">> Loaded a total of %i samples from json files." % len(samplesdict))
+    print("requested_years:", requested_years)
+
     if requested_years is not None:
+        print([sample.get("year") for sample in samplesdict.values()])
         samplesdict = {
             name: sample
             for name, sample in samplesdict.items()

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -486,7 +486,8 @@ if __name__ == "__main__":
         hist_lst = ["njets", "lj0pt", "ptz"]
         if tau_h_analysis:
             hist_lst.append("ptz_wtau")
-            hist_lst.append("tau0pt")
+            hist_lst.append("tau0Tpt")
+            hist_lst.append("tau0Fpt")
         if fwd_analysis:
             hist_lst.append("lt")
         if "lepton_pt_vs_eta" not in hist_lst:
@@ -560,7 +561,8 @@ if __name__ == "__main__":
             # "l1_eta_vs_phi",
         ]
         if tau_h_analysis:
-            hist_lst.append("tau0pt")
+            hist_lst.append("tau0Tpt")
+            hist_lst.append("tau0Fpt")
     else:
         # We want to specify a custom list
         # If we don't specify this argument, it will be None, and the processor will fill all hists

--- a/input_samples/cfgs/NDSkim_2022EE_signal_samples.cfg
+++ b/input_samples/cfgs/NDSkim_2022EE_signal_samples.cfg
@@ -1,10 +1,16 @@
 root://skynet013.crc.nd.edu/
 #file:///cms/cephfs/data
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_ttHnobb-1Jets_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_ttHnobb_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TTLL_MLL-4to50_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TTLL_MLL-50_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TTTT_NDSkim.json
-#../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TZQB-4FS_OnshellZ_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TZQB-Zto2L-4FS_MLL-30_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TTLNu_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_ttHnobb-1Jets_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_ttHnobb_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TTLL_MLL-4to50_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TTLL_MLL-50_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TTTT_NDSkim.json
+# #../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TZQB-4FS_OnshellZ_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TZQB-Zto2L-4FS_MLL-30_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TTLNu_NDSkim.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022EE/2022EE_tHq.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022EE/2022EE_tllq.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022EE/2022EE_ttH.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022EE/2022EE_ttll.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022EE/2022EE_ttlnu.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022EE/2022EE_tttt.json

--- a/input_samples/cfgs/NDSkim_2022_signal_samples.cfg
+++ b/input_samples/cfgs/NDSkim_2022_signal_samples.cfg
@@ -1,11 +1,17 @@
 # Central 2022 background samples
 root://skynet013.crc.nd.edu/
 #file:///cms/cephfs/data/
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_ttHnobb-1Jets_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_ttHnobb_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TTLL_MLL-4to50_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TTLL_MLL-50_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TTLNu_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TTTT_NDSkim.json
-#../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TZQB-4FS_OnshellZ_NDSkim.json #not recommended by MC contacts
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TZQB-Zto2L-4FS_MLL-30_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_ttHnobb-1Jets_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_ttHnobb_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TTLL_MLL-4to50_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TTLL_MLL-50_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TTLNu_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TTTT_NDSkim.json
+# #../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TZQB-4FS_OnshellZ_NDSkim.json #not recommended by MC contacts
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TZQB-Zto2L-4FS_MLL-30_NDSkim.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_tHq.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_tllq.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_ttH.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_ttll.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_ttlnu.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_tttt.json

--- a/input_samples/cfgs/NDSkim_2023BPix_signal_samples.cfg
+++ b/input_samples/cfgs/NDSkim_2023BPix_signal_samples.cfg
@@ -1,9 +1,15 @@
 root://skynet013.crc.nd.edu/
 #file:///cms/cephfs/data/
-#../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_ttHnobb-1Jets_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_ttHnobb_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TTLL_MLL-4to50_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TTLL_MLL-50_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TTLNu_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TTTT_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TZQB-Zto2L-4FS_MLL-30_NDSkim.json
+# #../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_ttHnobb-1Jets_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_ttHnobb_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TTLL_MLL-4to50_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TTLL_MLL-50_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TTLNu_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TTTT_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TZQB-Zto2L-4FS_MLL-30_NDSkim.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023BPix/2023BPix_tHq.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023BPix/2023BPix_tllq.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023BPix/2023BPix_ttH.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023BPix/2023BPix_ttll.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023BPix/2023BPix_ttlnu.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023BPix/2023BPix_tttt.json

--- a/input_samples/cfgs/NDSkim_2023_signal_samples.cfg
+++ b/input_samples/cfgs/NDSkim_2023_signal_samples.cfg
@@ -1,9 +1,15 @@
 root://skynet013.crc.nd.edu/
 #file:///cms/cephfs/data/
-#../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_ttHnobb-1Jets_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_ttHnobb_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TTLL_MLL-4to50_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TTLL_MLL-50_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TTLNu_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TTTT_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TZQB-Zto2L-4FS_MLL-30_NDSkim.json
+# #../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_ttHnobb-1Jets_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_ttHnobb_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TTLL_MLL-4to50_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TTLL_MLL-50_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TTLNu_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TTTT_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TZQB-Zto2L-4FS_MLL-30_NDSkim.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023/2023_tHq.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023/2023_tllq.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023/2023_ttH.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023/2023_ttll.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023/2023_ttlnu.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023/2023_tttt.json

--- a/tests/test_make_cr_and_sr_plots.py
+++ b/tests/test_make_cr_and_sr_plots.py
@@ -21,6 +21,13 @@ class _DummyHist:
         self.scale_factors.append(factor)
 
 
+def _find_zero_yield_entry(summary, *, label, variable):
+    for entry in summary.get("channel_entries", []):
+        if entry.get("label") == label and entry.get("variable") == variable:
+            return entry
+    return None
+
+
 def test_unit_normalization_skips_empty_histograms(monkeypatch):
     dummy_mc = _DummyHist()
     dummy_data = _DummyHist()
@@ -56,7 +63,7 @@ def test_unit_normalization_skips_empty_histograms(monkeypatch):
     assert any("Skipping data unit normalization" in msg for msg in logged_messages)
 
 
-def test_unmatched_sample_gets_fallback_group(monkeypatch):
+def test_unmatched_sample_is_skipped_from_group_map(monkeypatch):
     process_axis = hist.axis.StrCategory([], name="process", growth=True)
     value_axis = hist.axis.Regular(2, 0.0, 2.0, name="lj0pt")
     h_mc = hist.Hist(process_axis, value_axis, storage=hist.storage.Double())
@@ -90,9 +97,10 @@ def test_unmatched_sample_gets_fallback_group(monkeypatch):
         group_map = make_cr_and_sr_plots.populate_group_map(samples, pattern_map)
 
     assert "Top" in group_map
-    assert "mysteryProcess" in group_map
-    assert group_map["mysteryProcess"] == ["mysteryProcess"]
-    assert any("mysteryProcess" in msg for msg in captured)
+    assert "mysteryProcess" not in group_map
+    assert any(
+        "mysteryProcess" in msg and "skipping" in msg.lower() for msg in captured
+    )
 
     plotted_calls = []
 
@@ -122,7 +130,9 @@ def test_unmatched_sample_gets_fallback_group(monkeypatch):
         mc_call = plotted_calls[0]
         mc_stack_inputs = mc_call["args"][0]
         stacked_total = np.sum(np.stack(mc_stack_inputs), axis=0)
-        mc_totals = h_mc[{"process": sum}].as_hist({}).values(flow=True)[1:]
+        mc_totals = (
+            h_mc[{"process": "ttbarSL"}].as_hist({}).values(flow=True)[1:]
+        )
         np.testing.assert_allclose(stacked_total, mc_totals)
 
         colors = mc_call["kwargs"].get("color", [])
@@ -198,6 +208,447 @@ def test_both_njets_preserves_variables_for_merged_output(tmp_path):
         "cr_2lss_1j_met.png",
         "cr_2lss_1j_njets.png",
     }.issubset(set(plot_names)), plot_names
+
+
+def test_sr_njets_channel_transform_matches_cr_behavior():
+    process_axis = hist.axis.StrCategory([], name="process", growth=True)
+    channel_axis = hist.axis.StrCategory([], name="channel", growth=True)
+    syst_axis = hist.axis.StrCategory([], name="systematic", growth=True)
+    njets_axis = hist.axis.Regular(1, 0.0, 1.0, name="njets")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, njets_axis
+    )
+
+    for channel in ("3l_m_offZ_1b", "3l_p_offZ_2b"):
+        hist_obj.fill(
+            process="ttH_central2022",
+            channel=channel,
+            systematic="nominal",
+            njets=0.5,
+            weight=1.0,
+        )
+
+    hist_inputs = {"njets": hist_obj}
+
+    region_ctx = make_cr_and_sr_plots.build_region_context(
+        "SR", hist_inputs, years=["2022"], unblind=True
+    )
+    payload = make_cr_and_sr_plots._prepare_variable_payload(
+        "njets", region_ctx, metadata_only=True
+    )
+
+    assert "njets" in payload["channel_transformations"]
+
+    channel_bins = payload["channel_dict"].get("3l_offZ_SR")
+    assert channel_bins, "Expected SR channel bins for 3l_offZ_SR"
+
+    make_cr_and_sr_plots.validate_channel_group(
+        [hist_obj],
+        channel_bins,
+        payload["channel_transformations"],
+        region=region_ctx.name,
+        subgroup="3l_offZ_SR",
+        variable="njets",
+    )
+
+
+def test_sr_zero_yield_summary_respects_njets_aggregation(monkeypatch):
+    process_axis = hist.axis.StrCategory(
+        ["ttH_central2022", "data2022"], name="process"
+    )
+    channel_axis = hist.axis.StrCategory(
+        ["2lss_4t_m", "2lss_4t_p", "2lss_m", "2lss_p"], name="channel"
+    )
+    syst_axis = hist.axis.StrCategory(["nominal"], name="systematic")
+    njets_axis = hist.axis.Regular(1, 0.0, 1.0, name="njets")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, njets_axis
+    )
+
+    hist_obj.fill(
+        process="ttH_central2022",
+        channel="2lss_4t_m",
+        systematic="nominal",
+        njets=0.5,
+        weight=1.0,
+    )
+    hist_obj.fill(
+        process="data2022",
+        channel="2lss_4t_m",
+        systematic="nominal",
+        njets=0.5,
+        weight=0.0,
+    )
+    for channel in ("2lss_4t_p", "2lss_m", "2lss_p"):
+        hist_obj.fill(
+            process="data2022",
+            channel=channel,
+            systematic="nominal",
+            njets=0.5,
+            weight=0.0,
+        )
+
+    hist_inputs = {"njets": hist_obj}
+
+    patched_cfg = copy.deepcopy(
+        make_cr_and_sr_plots.REGION_PLOTTING.get("SR", {})
+    )
+    patched_cfg.update({"skip_variables": ["ptz"]})
+
+    with monkeypatch.context() as m:
+        m.setitem(make_cr_and_sr_plots.REGION_PLOTTING, "SR", patched_cfg)
+        region_ctx = make_cr_and_sr_plots.build_region_context(
+            "SR", hist_inputs, years=["2022"], unblind=True
+        )
+        summary = make_cr_and_sr_plots._summarize_zero_yield_processes(
+            hist_inputs,
+            region_name="SR",
+            region_ctx=region_ctx,
+            variables=["njets"],
+        )
+
+    entry = _find_zero_yield_entry(summary, label="2lss_SR", variable="njets")
+    assert entry is not None
+    assert not entry["missing_bins"]
+
+
+def test_sr_zero_yield_summary_flags_missing_channels_for_lj0pt():
+    process_axis = hist.axis.StrCategory(
+        ["ttH_central2022", "data2022"], name="process"
+    )
+    channel_axis = hist.axis.StrCategory(
+        ["2lss_4t_m_4j", "2lss_4t_m_5j"], name="channel"
+    )
+    syst_axis = hist.axis.StrCategory(["nominal"], name="systematic")
+    lj0pt_axis = hist.axis.Regular(1, 0.0, 1.0, name="lj0pt")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, lj0pt_axis
+    )
+
+    hist_obj.fill(
+        process="ttH_central2022",
+        channel="2lss_4t_m_4j",
+        systematic="nominal",
+        lj0pt=0.5,
+        weight=1.0,
+    )
+    hist_obj.fill(
+        process="data2022",
+        channel="2lss_4t_m_4j",
+        systematic="nominal",
+        lj0pt=0.5,
+        weight=0.0,
+    )
+    hist_obj.fill(
+        process="data2022",
+        channel="2lss_4t_m_5j",
+        systematic="nominal",
+        lj0pt=0.5,
+        weight=0.0,
+    )
+
+    hist_inputs = {"lj0pt": hist_obj}
+    region_ctx = make_cr_and_sr_plots.build_region_context(
+        "SR", hist_inputs, years=["2022"], unblind=True
+    )
+
+    summary = make_cr_and_sr_plots._summarize_zero_yield_processes(
+        hist_inputs,
+        region_name="SR",
+        region_ctx=region_ctx,
+        variables=["lj0pt"],
+    )
+
+    entry = _find_zero_yield_entry(summary, label="2lss_SR", variable="lj0pt")
+    assert entry is not None
+    assert "2lss_4t_m_6j" in entry["missing_bins"]
+    assert "2lss_4t_m_5j" not in entry["missing_bins"]
+
+    zero_processes = {proc for proc, _ in entry["zero_processes"]}
+    assert "data2022" in zero_processes
+
+
+def test_sr_zero_yield_summary_respects_skip_variables():
+    process_axis = hist.axis.StrCategory(["ttH_central2022"], name="process")
+    channel_axis = hist.axis.StrCategory(["3l_onZ_1b_2j"], name="channel")
+    syst_axis = hist.axis.StrCategory(["nominal"], name="systematic")
+    ptz_axis = hist.axis.Regular(1, 0.0, 1.0, name="ptz")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, ptz_axis
+    )
+
+    hist_obj.fill(
+        process="ttH_central2022",
+        channel="3l_onZ_1b_2j",
+        systematic="nominal",
+        ptz=0.5,
+        weight=1.0,
+    )
+
+    hist_inputs = {"ptz": hist_obj}
+    region_ctx = make_cr_and_sr_plots.build_region_context(
+        "SR", hist_inputs, years=["2022"], unblind=True
+    )
+
+    summary = make_cr_and_sr_plots._summarize_zero_yield_processes(
+        hist_inputs,
+        region_name="SR",
+        region_ctx=region_ctx,
+        variables=["ptz"],
+    )
+
+    assert not summary["channel_entries"]
+
+
+def test_cr_zero_yield_summary_respects_skip_variables(monkeypatch):
+    process_axis = hist.axis.StrCategory(["ttH_central2022"], name="process")
+    channel_axis = hist.axis.StrCategory(["2lss_ee_CR_1j"], name="channel")
+    syst_axis = hist.axis.StrCategory(["nominal"], name="systematic")
+    ptz_axis = hist.axis.Regular(1, 0.0, 1.0, name="ptz")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, ptz_axis
+    )
+
+    hist_obj.fill(
+        process="ttH_central2022",
+        channel="2lss_ee_CR_1j",
+        systematic="nominal",
+        ptz=0.5,
+        weight=1.0,
+    )
+
+    hist_inputs = {"ptz": hist_obj}
+
+    patched_cfg = copy.deepcopy(
+        make_cr_and_sr_plots.REGION_PLOTTING.get("CR", {})
+    )
+    patched_cfg.update({"skip_variables": ["ptz"]})
+
+    with monkeypatch.context() as m:
+        m.setitem(make_cr_and_sr_plots.REGION_PLOTTING, "CR", patched_cfg)
+        region_ctx = make_cr_and_sr_plots.build_region_context(
+            "CR", hist_inputs, years=["2022"], unblind=True
+        )
+        summary = make_cr_and_sr_plots._summarize_zero_yield_processes(
+            hist_inputs,
+            region_name="CR",
+            region_ctx=region_ctx,
+            variables=["ptz"],
+        )
+
+    assert not summary["channel_entries"]
+
+
+def test_cr_zero_yield_summary_reports_variable_and_missing_bins():
+    process_axis = hist.axis.StrCategory(
+        ["ttH_central2022", "data2022"], name="process"
+    )
+    channel_axis = hist.axis.StrCategory(
+        ["2lss_ee_CR_1j", "2lss_mm_CR_1j"], name="channel"
+    )
+    syst_axis = hist.axis.StrCategory(["nominal"], name="systematic")
+    met_axis = hist.axis.Regular(1, 0.0, 1.0, name="met")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, met_axis
+    )
+
+    for channel in ("2lss_ee_CR_1j", "2lss_mm_CR_1j"):
+        hist_obj.fill(
+            process="ttH_central2022",
+            channel=channel,
+            systematic="nominal",
+            met=0.5,
+            weight=1.0,
+        )
+        hist_obj.fill(
+            process="data2022",
+            channel=channel,
+            systematic="nominal",
+            met=0.5,
+            weight=0.0,
+        )
+
+    hist_inputs = {"met": hist_obj}
+    region_ctx = make_cr_and_sr_plots.build_region_context(
+        "CR", hist_inputs, years=["2022"], unblind=True
+    )
+
+    summary = make_cr_and_sr_plots._summarize_zero_yield_processes(
+        hist_inputs,
+        region_name="CR",
+        region_ctx=region_ctx,
+        variables=["met"],
+    )
+
+    entry = _find_zero_yield_entry(summary, label="cr_2lss", variable="met")
+    assert entry is not None
+    assert "2lss_mm_CR_2j" in entry["missing_bins"]
+
+    zero_processes = {proc for proc, _ in entry["zero_processes"]}
+    assert "data2022" in zero_processes
+
+
+def test_sr_zero_yield_skips_unmatched_processes(monkeypatch):
+    process_axis = hist.axis.StrCategory(
+        ["ttH_central2022", "ZG_MLL-50_PTG-600_central2022"], name="process"
+    )
+    channel_axis = hist.axis.StrCategory(["2lss_4t_m_4j"], name="channel")
+    syst_axis = hist.axis.StrCategory(["nominal"], name="systematic")
+    lj0pt_axis = hist.axis.Regular(1, 0.0, 1.0, name="lj0pt")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, lj0pt_axis
+    )
+
+    hist_obj.fill(
+        process="ttH_central2022",
+        channel="2lss_4t_m_4j",
+        systematic="nominal",
+        lj0pt=0.5,
+        weight=1.0,
+    )
+    hist_obj.fill(
+        process="ZG_MLL-50_PTG-600_central2022",
+        channel="2lss_4t_m_4j",
+        systematic="nominal",
+        lj0pt=0.5,
+        weight=1.0,
+    )
+
+    hist_inputs = {"lj0pt": hist_obj}
+
+    with monkeypatch.context() as m:
+        warnings = []
+
+        def _capture_warning(msg, *args, **kwargs):
+            if args:
+                msg = msg % args
+            warnings.append(msg)
+
+        m.setattr(make_cr_and_sr_plots.logger, "warning", _capture_warning)
+        region_ctx = make_cr_and_sr_plots.build_region_context(
+            "SR", hist_inputs, years=["2022"], unblind=True
+        )
+        summary = make_cr_and_sr_plots._summarize_zero_yield_processes(
+            hist_inputs,
+            region_name="SR",
+            region_ctx=region_ctx,
+            variables=["lj0pt"],
+        )
+
+    assert any("ZG_MLL-50_PTG-600_central2022" in msg for msg in warnings)
+    unmatched_present = any(
+        proc == "ZG_MLL-50_PTG-600_central2022"
+        for entry in summary["channel_entries"]
+        for proc, _ in entry["zero_processes"]
+    )
+    assert not unmatched_present
+
+
+def test_cr_zero_yield_skips_unmatched_processes(monkeypatch):
+    process_axis = hist.axis.StrCategory(
+        ["TTTo2L2Nu_central2022", "mysteryProc2022"], name="process"
+    )
+    channel_axis = hist.axis.StrCategory(["2lss_ee_CR_1j"], name="channel")
+    syst_axis = hist.axis.StrCategory(["nominal"], name="systematic")
+    met_axis = hist.axis.Regular(1, 0.0, 1.0, name="met")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, met_axis
+    )
+
+    hist_obj.fill(
+        process="TTTo2L2Nu_central2022",
+        channel="2lss_ee_CR_1j",
+        systematic="nominal",
+        met=0.5,
+        weight=1.0,
+    )
+    hist_obj.fill(
+        process="mysteryProc2022",
+        channel="2lss_ee_CR_1j",
+        systematic="nominal",
+        met=0.5,
+        weight=1.0,
+    )
+
+    hist_inputs = {"met": hist_obj}
+
+    with monkeypatch.context() as m:
+        warnings = []
+
+        def _capture_warning(msg, *args, **kwargs):
+            if args:
+                msg = msg % args
+            warnings.append(msg)
+
+        m.setattr(make_cr_and_sr_plots.logger, "warning", _capture_warning)
+        region_ctx = make_cr_and_sr_plots.build_region_context(
+            "CR", hist_inputs, years=["2022"], unblind=True
+        )
+        summary = make_cr_and_sr_plots._summarize_zero_yield_processes(
+            hist_inputs,
+            region_name="CR",
+            region_ctx=region_ctx,
+            variables=["met"],
+        )
+
+    assert any("mysteryProc2022" in msg for msg in warnings)
+    unmatched_present = any(
+        proc == "mysteryProc2022"
+        for entry in summary["channel_entries"]
+        for proc, _ in entry["zero_processes"]
+    )
+    assert not unmatched_present
+
+
+def test_sr_aggregate_blinded_uses_mc_when_data_empty(tmp_path):
+    process_axis = hist.axis.StrCategory([], name="process", growth=True)
+    channel_axis = hist.axis.StrCategory([], name="channel", growth=True)
+    syst_axis = hist.axis.StrCategory([], name="systematic", growth=True)
+    njets_axis = hist.axis.Regular(1, 0.0, 1.0, name="njets")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, njets_axis
+    )
+
+    hist_obj.fill(
+        process="ttH_central2022",
+        channel="2lss_p",
+        systematic="nominal",
+        njets=0.5,
+        weight=5.0,
+    )
+    hist_obj.fill(
+        process="data2022",
+        channel="2lss_p",
+        systematic="nominal",
+        njets=0.5,
+        weight=0.0,
+    )
+
+    make_cr_and_sr_plots.run_plots_for_region(
+        "SR",
+        {"njets": hist_obj},
+        years=["2022"],
+        save_dir_path=str(tmp_path),
+        channel_output="merged",
+        skip_syst_errs=True,
+        workers=1,
+        verbose=False,
+        unblind=False,
+    )
+
+    plot_dir = tmp_path / "2lss_SR"
+    assert plot_dir.exists()
+    plot_paths = list(plot_dir.glob("*_njets.png"))
+    assert plot_paths, "Expected SR aggregate plot when MC is non-zero and data is empty"
 
 
 def test_data_driven_samples_preserved_for_1tau_cr():

--- a/tools/audit_cr_channels_from_processor.py
+++ b/tools/audit_cr_channels_from_processor.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+import argparse
+import copy
+import json
+import sys
+from collections import OrderedDict
+from pathlib import Path
+
+import yaml
+
+CH_LST_PATH = Path("topeft/channels/ch_lst.json")
+META_YAML_PATH = Path("topeft/params/cr_sr_plots_metadata.yml")
+
+REGION_SPECS = {
+    "CR": {
+        "ch_lst_keys": ("CH_LST_CR", "TAU_CH_LST_CR"),
+        "yaml_key": "CR_CHAN_DICT",
+        # For CRs we assume the processor was run with --split-lep-flavor
+        "split_lep_flavor": True,
+    },
+    "SR": {
+        "ch_lst_keys": (),
+        "ch_lst_match": "CH_LST_SR",
+        "yaml_key": "SR_CHAN_DICT",
+        # For SRs we assume the processor was run without --split-lep-flavor
+        "split_lep_flavor": False,
+    },
+}
+
+# Semantic SR groups derived from channels.
+# No 1b/2b categorization at group level: 3l_1tau collects all 3l+1tau channels.
+SR_TAG_GROUP_RULES = {
+    "2lss_SR": {
+        "base": "2lss",
+        "require": [],
+        "forbid": ["fwd"],
+    },
+    "2lss_fwd": {
+        "base": "2l",
+        "require": ["fwd"],
+        "forbid": [],
+    },
+    "2lss_1tau_onZ": {
+        "base": "2lss_1tau",
+        "require": ["onZ"],
+        "forbid": [],
+    },
+    "2lss_1tau_offZ": {
+        "base": "2lss_1tau",
+        "require": ["offZ"],
+        "forbid": [],
+    },
+    "2los_onZ_1tau": {
+        "base": "2los_1tau",
+        "require": ["onZ", "1tau"],
+        "forbid": [],
+    },
+    "3l_onZ_SR": {
+        "base": "3l",
+        "require": ["onZ"],
+        "forbid": ["1tau", "fwd"],
+    },
+    "3l_offZ_SR": {
+        "base": "3l",
+        "require": ["offZ"],
+        "forbid": ["1tau", "fwd"],
+    },
+    # Combined 3l+1tau group (no 1b/2b split at group level)
+    "3l_1tau": {
+        "base": "3l",
+        "require": ["1tau"],
+        "forbid": ["fwd"],
+    },
+    "4l_SR": {
+        "base": "4l",
+        "require": [],
+        "forbid": [],
+    },
+}
+
+
+def _postprocess_sr_groups(sr_dict):
+    """
+    Apply higher-level physics/plotting conventions to SR_CHAN_DICT:
+      * rename 3l_fwd -> 3l_onZ_fwd (it only contains onZ channels);
+      * drop global base groups that are fully covered by more semantic ones.
+
+    This function must NOT drop any unique channel labels: only rename or
+    redistribute them into more specific groups.
+    """
+    sr_dict = copy.deepcopy(sr_dict)
+
+    # 1) Rename 3l_fwd -> 3l_onZ_fwd (it only contains onZ channels)
+    if "3l_fwd" in sr_dict:
+        if "3l_onZ_fwd" in sr_dict:
+            raise ValueError(
+                "3l_onZ_fwd already exists when trying to rename 3l_fwd"
+            )
+        sr_dict["3l_onZ_fwd"] = sr_dict.pop("3l_fwd")
+
+    # 2) Drop global / redundant SR bases which are now covered by semantic groups.
+    #    We now also drop '2l' after introducing the 2lss_fwd semantic group,
+    #    so that every 2l(SS) channel lives in exactly one high-level category.
+    for key in ("3l", "4l", "2los_1tau", "2l"):
+        sr_dict.pop(key, None)
+
+    return sr_dict
+
+
+def _construct_cat_name(chan_str, njet_str=None, flav_str=None):
+    """Match analysis_processor.construct_cat_name for channel labels.
+
+    For CRs (split_lep_flavor=True) we expect flav_str to be non-None and
+    produce labels like:  3l_eee_CR_0j
+    For SRs (split_lep_flavor=False) we pass flav_str=None and produce:
+      3l_CR_0j, 3l_m_offZ_1b_2j, etc.
+    """
+    nlep_str = chan_str.split("_")[0]
+    chan_str = "_".join(chan_str.split("_")[1:])
+    if chan_str == "":
+        chan_str = None
+
+    if njet_str is not None:
+        njet_str = njet_str[-2:]
+        if "j" not in njet_str:
+            raise ValueError(
+                f"Invalid njet string '{njet_str}' derived from '{njet_str}'"
+            )
+
+    ret_str = nlep_str
+    for component in [flav_str, chan_str, njet_str]:
+        if component is None:
+            continue
+        ret_str = "_".join([ret_str, component])
+    return ret_str
+
+
+def _jet_cat_to_key(jet_cat):
+    jet_cat = str(jet_cat)
+    if jet_cat.startswith("="):
+        jettag = "exactly_"
+    elif jet_cat.startswith("<"):
+        jettag = "atmost_"
+    elif jet_cat.startswith(">"):
+        jettag = "atleast_"
+    else:
+        raise ValueError(f"jet_cat {jet_cat} misses =,<,>!")
+
+    return jettag + jet_cat.replace("=", "").replace("<", "").replace(">", "") + "j"
+
+
+def _iter_channel_defs(cat_def):
+    lep_chan_lst = cat_def.get("lep_chan_lst", [])
+    for entry in lep_chan_lst:
+        if isinstance(entry, (list, tuple)):
+            if entry:
+                yield entry[0]
+        else:
+            yield entry
+
+
+def _resolve_ch_lst_keys(region_name, ch_cfg):
+    spec = REGION_SPECS[region_name]
+    explicit_keys = list(spec.get("ch_lst_keys", ()))
+    if explicit_keys:
+        missing = [key for key in explicit_keys if key not in ch_cfg]
+        if missing:
+            raise KeyError(
+                f"Missing expected {region_name} ch_lst keys: {', '.join(missing)}"
+            )
+        return explicit_keys
+
+    match_token = spec.get("ch_lst_match")
+    if match_token:
+        matched = sorted(key for key in ch_cfg if match_token in key)
+        if matched:
+            return matched
+
+    raise KeyError(
+        f"Unable to resolve {region_name} ch_lst keys from {', '.join(ch_cfg.keys())}"
+    )
+
+
+def _matches_tags(ch, require=(), forbid=()):
+    """Return True when all require tags are present and no forbid tags match."""
+    return all(tag in ch for tag in require) and not any(tag in ch for tag in forbid)
+
+
+def build_channel_labels_from_ch_cfg(
+    ch_cfg: dict, ch_lst_keys, split_lep_flavor: bool
+) -> OrderedDict:
+    """
+    Reverse-engineered from topeft/analysis_processor.py, but implemented here.
+
+    If split_lep_flavor is True (CR), we expand over lep_flav_lst and include
+    the flavor in the label (e.g. 3l_eee_CR_0j).
+
+    If split_lep_flavor is False (SR), we ignore lep_flav_lst and build labels
+    without explicit flavor (e.g. 3l_CR_0j, 3l_m_offZ_1b_2j).
+
+    Returns a mapping:
+        base_name -> ordered list of full channel labels
+
+    The returned labels must match the histogram channel labels
+    that CR_CHAN_DICT or SR_CHAN_DICT refer to.
+    """
+
+    out = OrderedDict()
+    seen_by_base = {}
+
+    for key in ch_lst_keys:
+        cat_block = ch_cfg.get(key) or {}
+        for base_name, cat_def in cat_block.items():
+            lep_flavs = list(cat_def.get("lep_flav_lst", []) or [None])
+            jet_lst = cat_def.get("jet_lst", [])
+            labels = out.setdefault(base_name, [])
+            seen = seen_by_base.setdefault(base_name, set(labels))
+
+            for jet_cat in jet_lst:
+                jet_key = _jet_cat_to_key(jet_cat)
+
+                # Decide whether to expand over lep_flav_lst
+                if split_lep_flavor:
+                    flav_loop = lep_flavs
+                else:
+                    flav_loop = [None]
+
+                for lep_chan in _iter_channel_defs(cat_def):
+                    for lep_flav in flav_loop:
+                        label = _construct_cat_name(
+                            lep_chan,
+                            njet_str=jet_key,
+                            flav_str=lep_flav,
+                        )
+                        if label in seen:
+                            continue
+                        seen.add(label)
+                        labels.append(label)
+
+    return out
+
+
+def _build_semantic_sr_groups(sr_proc_bases):
+    groups = {}
+    for group_name, rule in SR_TAG_GROUP_RULES.items():
+        base = rule["base"]
+        if base not in sr_proc_bases:
+            continue
+        base_channels = sr_proc_bases[base]
+        require = tuple(rule.get("require", ()))
+        forbid = tuple(rule.get("forbid", ()))
+        matches = [
+            ch
+            for ch in base_channels
+            if _matches_tags(ch, require=require, forbid=forbid)
+        ]
+        groups[group_name] = sorted(matches)
+    return groups
+
+
+def _collect_region_data(region_name, ch_cfg, meta_cfg):
+    spec = REGION_SPECS[region_name]
+    ch_lst_keys = _resolve_ch_lst_keys(region_name, ch_cfg)
+    split_lep_flavor = bool(spec.get("split_lep_flavor", False))
+
+    proc_map = build_channel_labels_from_ch_cfg(
+        ch_cfg, ch_lst_keys, split_lep_flavor=split_lep_flavor
+    )
+
+    yaml_key = spec["yaml_key"]
+    if yaml_key not in meta_cfg:
+        raise KeyError(f"Missing expected YAML key '{yaml_key}'")
+
+    yaml_block = meta_cfg.get(yaml_key) or {}
+    yaml_labels_by_base = {
+        base: list(labels or []) for base, labels in yaml_block.items()
+    }
+
+    proc_labels = sorted({lab for labs in proc_map.values() for lab in labs})
+    yaml_labels = sorted(
+        {lab for labels in yaml_labels_by_base.values() for lab in labels}
+    )
+
+    proc_set = set(proc_labels)
+    yaml_set = set(yaml_labels)
+
+    return {
+        "region": region_name,
+        "yaml_key": yaml_key,
+        "ch_lst_keys": ch_lst_keys,
+        "proc_map": proc_map,
+        "yaml_map": yaml_labels_by_base,
+        "proc_labels": proc_labels,
+        "yaml_labels": yaml_labels,
+        "only_in_processor": sorted(proc_set - yaml_set),
+        "only_in_yaml": sorted(yaml_set - proc_set),
+    }
+
+
+def _print_region_report(region_data):
+    region = region_data["region"]
+    yaml_key = region_data["yaml_key"]
+
+    print(
+        f"=== {region} channel labels that the PROCESSOR can build, but are MISSING in YAML {yaml_key} ==="
+    )
+    for lab in region_data["only_in_processor"]:
+        print(f"  - {lab}")
+
+    print(
+        f"\n=== YAML {yaml_key} labels that the PROCESSOR would NEVER produce ==="
+    )
+    for lab in region_data["only_in_yaml"]:
+        print(f"  - {lab}")
+
+    print(f"\n=== Debug: processor {region} bases and their first few channels ===")
+    for base, labs in sorted(region_data["proc_map"].items()):
+        labs_sorted = sorted(labs)
+        preview = ", ".join(labs_sorted[:5])
+        more = "" if len(labs_sorted) <= 5 else f" ... (+{len(labs_sorted)-5} more)"
+        print(f"  {base}: {preview}{more}")
+
+
+def _augment_channel_dict(proc_map, yaml_block):
+    updated = copy.deepcopy(yaml_block)
+    labels_added = 0
+    bases_created = 0
+
+    for base, proc_labels in proc_map.items():
+        if base not in updated:
+            updated[base] = list(proc_labels)
+            bases_created += 1
+            labels_added += len(proc_labels)
+            continue
+
+        existing = list(updated.get(base) or [])
+        existing_set = set(existing)
+        additions = [label for label in proc_labels if label not in existing_set]
+        if additions:
+            existing.extend(additions)
+            updated[base] = existing
+            labels_added += len(additions)
+
+    return updated, labels_added, bases_created
+
+
+def _exit_with_error(message):
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _read_json(path: Path):
+    try:
+        with path.open() as f:
+            return json.load(f)
+    except OSError as exc:
+        _exit_with_error(f"unable to read JSON from {path}: {exc}")
+    except json.JSONDecodeError as exc:
+        _exit_with_error(f"invalid JSON in {path}: {exc}")
+
+
+def _read_yaml(path: Path):
+    try:
+        with path.open() as f:
+            return yaml.safe_load(f)
+    except OSError as exc:
+        _exit_with_error(f"unable to read YAML from {path}: {exc}")
+    except yaml.YAMLError as exc:
+        _exit_with_error(f"invalid YAML in {path}: {exc}")
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Audit CR/SR channel labels from ch_lst.json against the YAML metadata."
+        )
+    )
+    parser.add_argument(
+        "--ch-lst",
+        default=str(CH_LST_PATH),
+        help="Path to ch_lst.json (default: topeft/channels/ch_lst.json)",
+    )
+    parser.add_argument(
+        "--meta-yaml",
+        default=str(META_YAML_PATH),
+        help="Path to cr_sr_plots_metadata.yml (default: topeft/params/cr_sr_plots_metadata.yml)",
+    )
+    parser.add_argument(
+        "--out-meta-yaml",
+        default=None,
+        help="Output path for the augmented YAML (required with --write-augmented-yaml)",
+    )
+    parser.add_argument(
+        "--regions",
+        choices=("CR", "SR", "both"),
+        default="both",
+        help="Which region(s) to audit (default: both)",
+    )
+    parser.add_argument(
+        "--write-augmented-yaml",
+        action="store_true",
+        help="Write an augmented YAML with missing labels filled in",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+
+    if args.write_augmented_yaml and not args.out_meta_yaml:
+        raise ValueError("--out-meta-yaml is required with --write-augmented-yaml")
+
+    ch_lst_path = Path(args.ch_lst)
+    meta_yaml_path = Path(args.meta_yaml)
+
+    ch_cfg = _read_json(ch_lst_path)
+    meta_cfg = _read_yaml(meta_yaml_path)
+
+    regions = ["CR", "SR"] if args.regions == "both" else [args.regions]
+
+    region_data = []
+    for region in regions:
+        data = _collect_region_data(region, ch_cfg, meta_cfg)
+        region_data.append(data)
+        _print_region_report(data)
+
+    if not args.write_augmented_yaml:
+        return
+
+    out_meta = copy.deepcopy(meta_cfg)
+    for data in region_data:
+        yaml_key = data["yaml_key"]
+
+        # Do NOT modify CR_CHAN_DICT: keep it identical to the input YAML.
+        if data["region"] != "SR":
+            out_meta[yaml_key] = meta_cfg.get(yaml_key, {})
+            print(
+                f"\n=== Skipping augmentation for {data['region']} "
+                f"(leaving {yaml_key} unchanged) ==="
+            )
+            continue
+
+        # For SR, augment + apply semantic/post-processing rules.
+        updated, labels_added, bases_created = _augment_channel_dict(
+            data["proc_map"], out_meta.get(yaml_key, {})
+        )
+
+        semantic_groups = _build_semantic_sr_groups(data["proc_map"])
+        for name, chans in semantic_groups.items():
+            updated[name] = chans
+
+        # Drop obsolete fixed-jet 4l groups if present
+        for obsolete in ("4l_2j", "4l_3j", "4l_4j"):
+            updated.pop(obsolete, None)
+
+        # Apply higher-level SR post-processing: rename and clean up groups
+        updated = _postprocess_sr_groups(updated)
+
+        out_meta[yaml_key] = updated
+
+        proc_count = sum(len(labels) for labels in data["proc_map"].values())
+        yaml_count = sum(len(labels) for labels in data["yaml_map"].values())
+        print(f"\n=== Augmented YAML summary ({data['region']}) ===")
+        print(f"  processor labels: {proc_count}")
+        print(f"  yaml labels: {yaml_count}")
+        print(f"  labels added: {labels_added}")
+        print(f"  bases created: {bases_created}")
+
+    out_path = Path(args.out_meta_yaml)
+    with out_path.open("w") as f:
+        yaml.safe_dump(out_meta, f, sort_keys=False)
+
+    print(f"\nWrote augmented YAML to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/topeft/channels/ch_lst.json
+++ b/topeft/channels/ch_lst.json
@@ -381,10 +381,10 @@
             "jet_lst": [
                 "=2",
                 "=3",
-                ">4"
+                "=4"
             ]
         },
-        "1l_1tau_CR": {
+        "1l_1tau_CRtt": {
             "lep_chan_lst": [
                 [
                     "1l_1tau_CR",
@@ -398,8 +398,7 @@
                 "m"
             ],
             "appl_lst": [
-                "isSR_1l",
-                "isAR_1l"
+                "isSR_1l"
             ],
             "jet_lst": [
                 "=2",
@@ -407,7 +406,7 @@
                 "=4"
             ]
         },
-        "1l_dy_tautau_CR": {
+        "1l_1tau_CRDY": {
             "lep_chan_lst": [
                 [
                     "1l_dy_tautau_CR",
@@ -430,38 +429,15 @@
                 "=3",
                 "=4"
             ]
-        }
-    },
-    "OFFZ_SPLIT_CH_LST_SR": {
-        "2l": {
+        },
+        "2l_CR": {
             "lep_chan_lst": [
                 [
-                    "2lss_p",
+                    "2lss_CR",
+                    "chargedl0",
                     "2lss",
-                    "2l_p",
-                    "bmask_atleast1m2l",
-                    "bmask_atmost2m"
-                ],
-                [
-                    "2lss_m",
-                    "2lss",
-                    "2l_m",
-                    "bmask_atleast1m2l",
-                    "bmask_atmost2m"
-                ],
-                [
-                    "2lss_4t_p",
-                    "2lss",
-                    "2l_p",
-                    "bmask_atleast1m2l",
-                    "bmask_atleast3m"
-                ],
-                [
-                    "2lss_4t_m",
-                    "2lss",
-                    "2l_m",
-                    "bmask_atleast1m2l",
-                    "bmask_atleast3m"
+                    "bmask_exactly1m",
+                    "0tau"
                 ]
             ],
             "lep_flav_lst": [
@@ -477,97 +453,203 @@
                 "isAR_2lSS_OS"
             ],
             "jet_lst": [
-                "=4",
-                "=5",
-                "=6",
-                ">7"
+                "=1",
+                "=2",
+                "=3"
             ]
         },
-        "3l": {
+        "2l_CRflip": {
             "lep_chan_lst": [
                 [
-                    "3l_onZ_1b",
-                    "3l",
-                    "3l_onZ",
-                    "bmask_exactly1m"
-                ],
+                    "2lss_CRflip",
+                    "2l_nozeeveto",
+                    "2lee",
+                    "2l_onZ_as",
+                    "0tau"
+                ]
+            ],
+            "lep_flav_lst": [
+                "ee"
+            ],
+            "appl_lst": [
+                "isSR_2lSS",
+                "isAR_2lSS"
+            ],
+            "appl_lst_data": [
+                "isAR_2lSS_OS"
+            ],
+            "jet_lst": [
+                "<3"
+            ]
+        },
+        "2los_CRZ": {
+            "lep_chan_lst": [
                 [
-                    "3l_onZ_2b",
+                    "2los_CRZ",
+                    "2l_nozeeveto",
+                    "2los",
+                    "2l_onZ",
+                    "bmask_exactly0m",
+                    "0tau"
+                ]
+            ],
+            "lep_flav_lst": [
+                "ee",
+                "mm"
+            ],
+            "appl_lst": [
+                "isSR_2lOS",
+                "isAR_2lOS"
+            ],
+            "jet_lst": [
+                ">0"
+            ]
+        },
+        "2los_CRtt": {
+            "lep_chan_lst": [
+                [
+                    "2los_CRtt",
+                    "2l_nozeeveto",
+                    "2los",
+                    "2lem",
+                    "bmask_exactly2m",
+                    "0tau"
+                ]
+            ],
+            "lep_flav_lst": [
+                "em"
+            ],
+            "appl_lst": [
+                "isSR_2lOS",
+                "isAR_2lOS"
+            ],
+            "jet_lst": [
+                "=2"
+            ]
+        },
+        "3l_CR": {
+            "lep_chan_lst": [
+                [
+                    "3l_CR",
                     "3l",
-                    "3l_onZ",
-                    "bmask_atleast2m"
-                ],
+                    "bmask_exactly0m",
+                    "0tau"
+                ]
+            ],
+            "lep_flav_lst": [
+                "eee",
+                "eem",
+                "emm",
+                "mmm"
+            ],
+            "appl_lst": [
+                "isSR_3l",
+                "isAR_3l"
+            ],
+            "jet_lst": [
+                "=0",
+                ">1"
+            ]
+        }
+    },
+    "OFFZ_TAU_SPLIT_CH_LST_SR": {
+        "3l": {
+            "lep_chan_lst": [
                 [
                     "3l_m_offZ_low_1b",
                     "3l_m",
                     "3l_offZ_low",
-                    "bmask_exactly1m"
+                    "bmask_exactly1m",
+		    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
                     "3l_m_offZ_high_1b",
                     "3l_m",
                     "3l_offZ_high",
-                    "bmask_exactly1m"
+                    "bmask_exactly1m",
+		    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
                     "3l_m_offZ_none_1b",
                     "3l_m",
                     "3l_offZ_none",
-                    "bmask_exactly1m"
+                    "bmask_exactly1m",
+		    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
                     "3l_m_offZ_low_2b",
                     "3l_m",
                     "3l_offZ_low",
-                    "bmask_atleast2m"
+                    "bmask_atleast2m",
+		    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
                     "3l_m_offZ_high_2b",
                     "3l_m",
                     "3l_offZ_high",
-                    "bmask_atleast2m"
+                    "bmask_atleast2m",
+		    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
                     "3l_m_offZ_none_2b",
                     "3l_m",
                     "3l_offZ_none",
-                    "bmask_atleast2m"
+                    "bmask_atleast2m",
+		    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
                     "3l_p_offZ_low_1b",
                     "3l_p",
                     "3l_offZ_low",
-                    "bmask_exactly1m"
+                    "bmask_exactly1m",
+		    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
                     "3l_p_offZ_high_1b",
                     "3l_p",
                     "3l_offZ_high",
-                    "bmask_exactly1m"
+                    "bmask_exactly1m",
+		    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
                     "3l_p_offZ_none_1b",
                     "3l_p",
                     "3l_offZ_none",
-                    "bmask_exactly1m"
+                    "bmask_exactly1m",
+		    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
                     "3l_p_offZ_low_2b",
                     "3l_p",
                     "3l_offZ_low",
-                    "bmask_atleast2m"
+                    "bmask_atleast2m",
+		    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
                     "3l_p_offZ_high_2b",
                     "3l_p",
                     "3l_offZ_high",
-                    "bmask_atleast2m"
+                    "bmask_atleast2m",
+		    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
                     "3l_p_offZ_none_2b",
                     "3l_p",
                     "3l_offZ_none",
-                    "bmask_atleast2m"
+                    "bmask_atleast2m",
+		    "~fwdjet_mask",
+		    "0tau"
                 ]
             ],
             "lep_flav_lst": [
@@ -585,26 +667,6 @@
                 "=3",
                 "=4",
                 ">5"
-            ]
-        },
-        "4l": {
-            "lep_chan_lst": [
-                [
-                    "4l",
-                    "4l",
-                    "bmask_atleast1m2l"
-                ]
-            ],
-            "lep_flav_lst": [
-                "llll"
-            ],
-            "appl_lst": [
-                "isSR_4l"
-            ],
-            "jet_lst": [
-                "=2",
-                "=3",
-                ">4"
             ]
         }
     },
@@ -725,8 +787,8 @@
                 ">1"
             ]
         }
-    },
-    "FWD_CH_LST_SR": {
+    },    
+    "ALL_CH_LST_SR": {
         "2l": {
             "lep_chan_lst": [
                 [
@@ -735,7 +797,8 @@
                     "2l_p",
                     "bmask_atleast1m2l",
                     "bmask_atmost2m",
-                    "~fwdjet_mask"
+                    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
                     "2lss_m",
@@ -743,35 +806,42 @@
                     "2l_m",
                     "bmask_atleast1m2l",
                     "bmask_atmost2m",
-                    "~fwdjet_mask"
+                    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
                     "2lss_4t_p",
                     "2lss",
                     "2l_p",
                     "bmask_atleast1m2l",
-                    "bmask_atleast3m"
+                    "bmask_atleast3m",
+		    "0tau"
                 ],
                 [
                     "2lss_4t_m",
                     "2lss",
                     "2l_m",
                     "bmask_atleast1m2l",
-                    "bmask_atleast3m"
+                    "bmask_atleast3m",
+		    "0tau"
                 ],
                 [
                     "2lss_fwd_p",
-                    "2lss_fwd",
-                    "2l_fwd_p",
+                    "2lss",
+                    "2l_p",
                     "bmask_atleast1m2l",
-                    "bmask_atmost2m"
+                    "bmask_atmost2m",
+		    "fwdjet_mask",
+		    "0tau"
                 ],
                 [
                     "2lss_fwd_m",
-                    "2lss_fwd",
-                    "2l_fwd_m",
+                    "2lss",
+                    "2l_m",
                     "bmask_atleast1m2l",
-                    "bmask_atmost2m"
+                    "bmask_atmost2m",
+		    "fwdjet_mask",
+		    "0tau"
                 ]
             ],
             "lep_flav_lst": [
@@ -793,60 +863,313 @@
                 ">7"
             ]
         },
+        "2lss_1tau": {
+            "lep_chan_lst": [
+                [
+                    "2lss_m_1tau_onZ",
+                    "2lss",
+                    "2l_m",
+                    "bmask_atleast1m2l",
+                    "1tau",
+                    "onZ_tau"
+                ],
+                [
+                    "2lss_p_1tau_offZ",
+                    "2lss",
+                    "2l_p",
+                    "bmask_atleast1m2l",
+                    "1tau",
+                    "offZ_tau"
+                ],
+                [
+                    "2lss_m_1tau_offZ",
+                    "2lss",
+                    "2l_m",
+                    "bmask_atleast1m2l",
+                    "1tau",
+                    "offZ_tau"
+                ],
+                [
+                    "2lss_p_1tau_onZ",
+                    "2lss",
+                    "2l_p",
+                    "bmask_atleast1m2l",
+                    "1tau",
+                    "onZ_tau"
+                ]
+            ],
+            "lep_flav_lst": [
+                "ee",
+                "em",
+                "mm"
+            ],
+            "appl_lst": [
+                "isSR_2lSS",
+                "isAR_2lSS"
+            ],
+            "appl_lst_data": [
+                "isAR_2lSS_OS"
+            ],
+            "jet_lst": [
+                "=3",
+                "=4",
+                "=5",
+                ">6"
+            ]
+        },
+        "2los_1tau": {
+            "lep_chan_lst": [
+                [
+                    "2los_onZ_1tau",
+                    "2los",
+                    "bmask_atleast2m",
+                    "1tau",
+                    "2l_onZ"
+                ]
+            ],
+            "lep_flav_lst": [
+                "ee",
+                "em",
+                "mm"
+            ],
+            "appl_lst": [
+                "isSR_2lOS",
+                "isAR_2lOS"
+            ],
+            "jet_lst": [
+                ">5"
+            ]
+        },
         "3l": {
             "lep_chan_lst": [
                 [
                     "3l_onZ_1b",
                     "3l",
                     "3l_onZ",
-                    "bmask_exactly1m"
+                    "bmask_exactly1m",
+                    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
                     "3l_onZ_2b",
                     "3l",
                     "3l_onZ",
-                    "bmask_atleast2m"
+                    "bmask_atleast2m",
+                    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
-                    "3l_m_offZ_1b",
+                    "3l_1tau_1b",
+                    "bmask_exactly1m",
+                    "1tau"
+                ],
+                [
+                    "3l_1tau_2b",
+                    "bmask_atleast2m",
+                    "1tau"
+                ],
+                [
+                    "3l_m_offZ_low_1b",
                     "3l_m",
-                    "3l_offZ",
-                    "bmask_exactly1m"
+                    "3l_offZ_low",
+                    "bmask_exactly1m",
+		    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
-                    "3l_m_offZ_2b",
+                    "3l_m_offZ_high_1b",
                     "3l_m",
-                    "3l_offZ",
-                    "bmask_atleast2m"
+                    "3l_offZ_high",
+                    "bmask_exactly1m",
+		    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
-                    "3l_p_offZ_1b",
-                    "3l_p",
-                    "3l_offZ",
-                    "bmask_exactly1m"
+                    "3l_m_offZ_none_1b",
+                    "3l_m",
+                    "3l_offZ_none",
+                    "bmask_exactly1m",
+		    "~fwdjet_mask",
+		    "0tau"
                 ],
                 [
-                    "3l_p_offZ_2b",
+                    "3l_m_offZ_low_2b",
+                    "3l_m",
+                    "3l_offZ_low",
+                    "bmask_atleast2m",
+		    "~fwdjet_mask",
+		    "0tau"
+                ],
+                [
+                    "3l_m_offZ_high_2b",
+                    "3l_m",
+                    "3l_offZ_high",
+                    "bmask_atleast2m",
+		    "~fwdjet_mask",
+		    "0tau"
+                ],
+                [
+                    "3l_m_offZ_none_2b",
+                    "3l_m",
+                    "3l_offZ_none",
+                    "bmask_atleast2m",
+		    "~fwdjet_mask",
+		    "0tau"
+                ],
+                [
+                    "3l_p_offZ_low_1b",
                     "3l_p",
-                    "3l_offZ",
-                    "bmask_atleast2m"
+                    "3l_offZ_low",
+                    "bmask_exactly1m",
+		    "~fwdjet_mask",
+		    "0tau"
+                ],
+                [
+                    "3l_p_offZ_high_1b",
+                    "3l_p",
+                    "3l_offZ_high",
+                    "bmask_exactly1m",
+		    "~fwdjet_mask",
+		    "0tau"
+                ],
+                [
+                    "3l_p_offZ_none_1b",
+                    "3l_p",
+                    "3l_offZ_none",
+                    "bmask_exactly1m",
+		    "~fwdjet_mask",
+		    "0tau"
+                ],
+                [
+                    "3l_p_offZ_low_2b",
+                    "3l_p",
+                    "3l_offZ_low",
+                    "bmask_atleast2m",
+		    "~fwdjet_mask",
+		    "0tau"
+                ],
+                [
+                    "3l_p_offZ_high_2b",
+                    "3l_p",
+                    "3l_offZ_high",
+                    "bmask_atleast2m",
+		    "~fwdjet_mask",
+		    "0tau"
+                ],
+                [
+                    "3l_p_offZ_none_2b",
+                    "3l_p",
+                    "3l_offZ_none",
+                    "bmask_atleast2m",
+		    "~fwdjet_mask",
+		    "0tau"
                 ]
             ],
             "lep_flav_lst": [
                 "eee",
                 "eem",
                 "emm",
-                "mmm"
+        "mmm"
             ],
             "appl_lst": [
                 "isSR_3l",
                 "isAR_3l"
             ],
             "jet_lst": [
+                "=1",
                 "=2",
                 "=3",
                 "=4",
                 ">5"
+            ]
+        },
+	"3l_fwd": {
+            "lep_chan_lst": [
+                [
+                    "3l_onZ_1b_fwd",
+                    "3l",
+                    "3l_onZ",
+                    "bmask_exactly1m",
+                    "fwdjet_mask",
+                    "0tau"
+                ],
+                [
+                    "3l_onZ_2b_fwd",
+                    "3l",
+                    "3l_onZ",
+                    "bmask_atleast2m",
+                    "fwdjet_mask",
+                    "0tau"
+                ]
+            ],
+            "lep_flav_lst": [
+                "eee",
+                "eem",
+                "emm",
+        "mmm"
+            ],
+            "appl_lst": [
+                "isSR_3l",
+                "isAR_3l"
+            ],
+            "jet_lst": [
+		"=1",
+                "=2",
+                "=3",
+                ">4"
+            ]
+        },
+        "3l_offZ_fwd": {
+            "lep_chan_lst": [
+                [
+                    "3l_m_offZ_1b_fwd",
+                    "3l_m",
+                    "3l_offZ",
+                    "bmask_exactly1m",
+                    "fwdjet_mask",
+                    "0tau"
+                ],
+                [
+                    "3l_p_offZ_1b_fwd",
+                    "3l_p",
+                    "3l_offZ",
+                    "bmask_exactly1m",
+                    "fwdjet_mask",
+                    "0tau"
+                ],
+                [
+                    "3l_m_offZ_2b_fwd",
+                    "3l_m",
+                    "3l_offZ",
+                    "bmask_atleast2m",
+                    "fwdjet_mask",
+                    "0tau"
+                ],
+
+                [
+                    "3l_p_offZ_2b_fwd",
+                    "3l_p",
+                    "3l_offZ",
+                    "bmask_atleast2m",
+                    "fwdjet_mask",
+                    "0tau"
+                ]
+        ],
+            "lep_flav_lst": [
+                "eee",
+                "eem",
+                "emm",
+        "mmm"
+            ],
+            "appl_lst": [
+                "isSR_3l",
+                "isAR_3l"
+            ],
+            "jet_lst": [
+                "=1",
+                "=2",
+                "=3",
+                ">4"
             ]
         },
         "4l": {

--- a/topeft/modules/axes.py
+++ b/topeft/modules/axes.py
@@ -111,10 +111,15 @@ info = {
         "variable": [0, 150, 250, 500],
         "label": r"pt of lepton hadronic tau pair (GeV) ",
     },
-    "tau0pt": {
+    "tau0Tpt": {
         "regular": (20, 0, 200),
         #"variable": [0, 150, 250, 500],
-        "label": r"pt of leading hadronic tau (GeV) ",
+        "label": r"pt of leading tight hadronic tau (GeV) ",
+    },
+    "tau0Fpt": {
+        "regular": (20, 0, 200),
+        #"variable": [0, 150, 250, 500],
+        "label": r"pt of leading FO hadronic tau (GeV) ",
     },
     "lt": {
         "regular": (12, 0, 600),

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -972,14 +972,14 @@ def AttachTauSF(events, taus, year, vsJetWP="Loose"):
                 )
             )
 
-            print("\n\n\n\n\n")
-            print("vsjet_flat_mask:", ak.to_list(vsjet_flat_mask))
-            print("vse_flat_mask:", ak.to_list(vse_flat_mask))
-            print("flat_pt:", ak.to_list(flat_pt))
-            print("flat_dm:", ak.to_list(flat_dm))
-            print("flat_gen:", ak.to_list(flat_gen))
-            print("ceval[discr].evaluate(*arg_sf):", ak.to_list(ceval[discr].evaluate(*arg_sf)))
-            print("\n\n\n\n\n")
+            # print("\n\n\n\n\n")
+            # print("vsjet_flat_mask:", ak.to_list(vsjet_flat_mask))
+            # print("vse_flat_mask:", ak.to_list(vse_flat_mask))
+            # print("flat_pt:", ak.to_list(flat_pt))
+            # print("flat_dm:", ak.to_list(flat_dm))
+            # print("flat_gen:", ak.to_list(flat_gen))
+            # print("ceval[discr].evaluate(*arg_sf):", ak.to_list(ceval[discr].evaluate(*arg_sf)))
+            # print("\n\n\n\n\n")
 
             if "VSjet" in discr:
                 arg_up = arg_list + ("up", "dm")

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -897,7 +897,7 @@ def AttachTauSF(events, taus, year, vsJetWP="Loose"):
         wp   = taus.idDeepTau2017v2p1VSjet
 
         ## legacy
-        whereFlag = ((pt>20) & (pt<205) & (gen==5) & (taus[f"is{vsJetWP}"]>0))
+        whereFlag = ((pt>20) & (pt<205) & (gen==5) & (taus[f"is{vsJetWP}"]>0) )
         real_sf_loose = np.where(whereFlag, SFevaluator[f'TauSF_{year}_{vsJetWP}'](dm,pt), 1)
         real_sf_loose_up = np.where(whereFlag, SFevaluator[f'TauSF_{year}_{vsJetWP}_up'](dm,pt), 1)
         real_sf_loose_down = np.where(whereFlag, SFevaluator[f'TauSF_{year}_{vsJetWP}_down'](dm,pt), 1)
@@ -940,8 +940,8 @@ def AttachTauSF(events, taus, year, vsJetWP="Loose"):
         deep_tau_cuts = [
             (
                 "DeepTau2018v2p5VSjet",
-                vsjet_flat_mask,
-                (flat_pt, flat_dm, flat_gen, vsJetWP, "Tight"),
+                (vsjet_flat_mask & vse_flat_mask),
+                (flat_pt, flat_dm, flat_gen, vsJetWP, "VVLoose"),
                 (flat_gen == 5),
             ),
             (
@@ -960,9 +960,10 @@ def AttachTauSF(events, taus, year, vsJetWP="Loose"):
             tau_mask_flat = ak.fill_none(id_mask_flat & pt_mask_flat & gen_mask_flat, False)
 
             if "VSjet" in discr:
-                arg_sf = arg_list + ("nom", "pt")
+                arg_sf = arg_list + ("nom", "dm")
             else:
                 arg_sf = arg_list + ("nom",)
+
             DT_sf_list.append(
                 ak.where(
                     ~tau_mask_flat,
@@ -972,7 +973,7 @@ def AttachTauSF(events, taus, year, vsJetWP="Loose"):
             )
 
             if "VSjet" in discr:
-                arg_up = arg_list + ("up", "pt")
+                arg_up = arg_list + ("up", "dm")
             else:
                 arg_up = arg_list + ("up",)
             DT_up_list.append(
@@ -983,7 +984,7 @@ def AttachTauSF(events, taus, year, vsJetWP="Loose"):
                 )
             )
             if "VSjet" in discr:
-                arg_down = arg_list + ("down", "pt")
+                arg_down = arg_list + ("down", "dm")
             else:
                 arg_down = arg_list + ("down",)
             DT_do_list.append(
@@ -1012,10 +1013,13 @@ def AttachTauSF(events, taus, year, vsJetWP="Loose"):
                 fake_elec_sf_up = ak.unflatten(DT_up_discr, ak.num(pt))
                 fake_elec_sf_down = ak.unflatten(DT_do_discr, ak.num(pt))
 
-        whereFlag = ((pt>20) & (pt<205) & (gen!=5) & (gen!=4) & (gen!=3) & (gen!=2) & (gen!=1) & (taus[f"is{vsJetWP}"]>0))
-        new_fake_sf = np.where(whereFlag, SFevaluator['TauFakeSF_Run3'](pt), 1)
-        new_fake_sf_up = np.where(whereFlag, SFevaluator['TauFakeSF_Run3_up'](pt), 1)
-        new_fake_sf_down = np.where(whereFlag, SFevaluator['TauFakeSF_Run3_down'](pt), 1)
+        # whereFlag = ((pt>20) & (pt<205) & (gen!=5) & (gen!=4) & (gen!=3) & (gen!=2) & (gen!=1) & (taus[f"is{vsJetWP}"]>0))
+        # new_fake_sf = np.where(whereFlag, SFevaluator['TauFakeSF_Run3'](pt), 1)
+        # new_fake_sf_up = np.where(whereFlag, SFevaluator['TauFakeSF_Run3_up'](pt), 1)
+        # new_fake_sf_down = np.where(whereFlag, SFevaluator['TauFakeSF_Run3_down'](pt), 1)
+        new_fake_sf = ak.fill_none(np.ones_like(pt, dtype=np.float32), 1.0)
+        new_fake_sf_up = ak.fill_none(np.ones_like(pt, dtype=np.float32), 1.0)
+        new_fake_sf_down = ak.fill_none(np.ones_like(pt, dtype=np.float32), 1.0)
 
         # Run3 tau muon SF may be needed in the future
         fake_muon_sf = ak.fill_none(np.ones_like(pt, dtype=np.float32), 1.0)
@@ -1493,7 +1497,6 @@ def AttachElectronSF(electrons, year, looseWP=None, useRun3MVA=True):
 
     if is_run3:
         if looseWP != "none":
-            #print("\n\n\n\n\nI'm applying EGM loose SFs\n\n\n\n\n")
             loose_sf_flat = None
             loose_up_flat = None
             loose_do_flat = None
@@ -1520,7 +1523,6 @@ def AttachElectronSF(electrons, year, looseWP=None, useRun3MVA=True):
             loose_up = ak.unflatten(loose_up_flat, ak.num(pt))
             loose_do = ak.unflatten(loose_do_flat, ak.num(pt))
         else:
-            #print("\n\n\n\n\nI'm NOT applying EGM loose SFs\n\n\n\n\n")
             loose_sf = ak.ones_like(reco_sf)
             loose_up = ak.ones_like(reco_sf)
             loose_do = ak.ones_like(reco_sf)
@@ -1599,14 +1601,6 @@ def AttachElectronSF(electrons, year, looseWP=None, useRun3MVA=True):
         iso_err = SFevaluator['ElecIsoSF_{year}_er'.format(year=year)](np.abs(eta),pt)
         iso_up = iso_sf + iso_err
         iso_do = iso_sf - iso_err
-
-    #print("\n\n\n\n\n\n\n")
-    #print('new_sf', new_sf)
-    #print('new_sf_2l', new_sf_2l)
-    #print('new_sf_3l', new_sf_3l)
-    #print('sf_nom_2l_elec', ak.to_list(reco_sf * new_sf_2l * loose_sf * iso_sf))
-    #print('sf_nom_3l_elec', ak.to_list(reco_sf * new_sf_2l * loose_sf))
-    #print("\n\n\n\n\n\n\n")
 
     electrons['sf_nom_2l_elec'] = reco_sf * new_sf_2l * loose_sf * iso_sf
     electrons['sf_hi_2l_elec']  = (reco_up) * new_up_2l * loose_up * iso_up

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -972,6 +972,15 @@ def AttachTauSF(events, taus, year, vsJetWP="Loose"):
                 )
             )
 
+            print("\n\n\n\n\n")
+            print("vsjet_flat_mask:", ak.to_list(vsjet_flat_mask))
+            print("vse_flat_mask:", ak.to_list(vse_flat_mask))
+            print("flat_pt:", ak.to_list(flat_pt))
+            print("flat_dm:", ak.to_list(flat_dm))
+            print("flat_gen:", ak.to_list(flat_gen))
+            print("ceval[discr].evaluate(*arg_sf):", ak.to_list(ceval[discr].evaluate(*arg_sf)))
+            print("\n\n\n\n\n")
+
             if "VSjet" in discr:
                 arg_up = arg_list + ("up", "dm")
             else:

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -645,7 +645,7 @@ def ApplyTES(year, taus, isData, vsJetWP="Loose"):
 
         # Genuine taus (genmatch==5) receive the TES weights
         tes_kin = (flat_pt > 20) & (flat_pt < 205)
-        tes_dm  = (flat_dm == 0) | (flat_dm == 1) | (flat_dm == 2) | (flat_dm == 10) | (flat_dm == 11)
+        tes_dm  = (flat_dm == 0) | (flat_dm == 1) | (flat_dm == 10) | (flat_dm == 11)
         tes_where = tes_kin & tes_dm & (flat_gen == 5)
 
         full_tes = np.ones_like(flat_all_pt_np, dtype=np.float32)
@@ -667,7 +667,7 @@ def ApplyTES(year, taus, isData, vsJetWP="Loose"):
 
         # Electron/muon fakes (genmatch 1-4) receive the FES weights
         fes_kin = (flat_pt > 20) & (flat_pt < 205)
-        fes_dm  = (flat_dm == 0) | (flat_dm == 1)
+        fes_dm  = (flat_dm == 0) | (flat_dm == 1) | (flat_dm == 10) | (flat_dm == 11)
         fes_where = fes_kin & fes_dm & (flat_gen >= 1) & (flat_gen <= 4)
 
         full_fes = np.ones_like(flat_all_pt_np, dtype=np.float32)

--- a/topeft/modules/object_selection.py
+++ b/topeft/modules/object_selection.py
@@ -92,7 +92,7 @@ class run3TauSelection:
 
         base_mask = (
             (pt > minpt)
-            & (abs(eta) < get_te_param("eta_t_cut"))
+            & (abs(eta) < get_te_param("eta_t_cut_run3"))
             & (abs(dxy) < get_te_param("dxy_tau_cut"))
             & (abs(dz) < get_te_param("dz_tau_cut"))
             & (idDeepTauVSe >= 2)

--- a/topeft/modules/yield_tools.py
+++ b/topeft/modules/yield_tools.py
@@ -34,12 +34,12 @@ class YieldTools():
         # A dictionary mapping names of processes in the processes axis to a short version of the name
         self.PROC_MAP = {
 
-            "ttlnu" : ["ttW_centralUL16APV"    ,"ttW_centralUL16"    ,"ttW_centralUL17" ,"ttW_centralUL18" , "ttlnuJet_privateUL18" , "ttlnuJet_privateUL17" , "ttlnuJet_privateUL16" , "ttlnuJet_privateUL16APV", "ttW_central2022",  "ttlnuJet_private2022"],
-            "ttll"  : ["ttZ_centralUL16APV"    ,"ttZ_centralUL16"    ,"ttZ_centralUL17" ,"ttZ_centralUL18" , "ttllJet_privateUL18"  , "ttllJet_privateUL17"  , "ttllJet_privateUL16"  , "ttllJet_privateUL16APV",  "TTLL_MLL-50_central2022", "TTLL_MLL-4to50_central2022" ,"TTLL_MLL-50_central2022EE", "TTLL_MLL-4to50_central2022EE"],
-            "ttH"   : ["ttHJet_centralUL16APV" ,"ttHJet_centralUL16" ,"ttH_centralUL17" ,"ttH_centralUL18" , "ttHJet_privateUL18"   , "ttHJet_privateUL17"   , "ttHJet_privateUL16"   , "ttHJet_privateUL16APV", "ttHnobb-1Jets_central2022",  "ttHnobb-1Jets_central2022EE"],
-            "tllq"  : ["tZq_centralUL16APV"    ,"tZq_centralUL16"    ,"tZq_centralUL17" ,"tZq_centralUL18" , "tllq_privateUL18"     , "tllq_privateUL17"     , "tllq_privateUL16"     , "tllq_privateUL16APV", "tZq_central2022", "tllq_private2022"],
-            "tHq"   : ["tHq_centralUL16APV"    ,"tHq_centralUL16"    ,"tHq_centralUL17" ,"tHq_centralUL18" , "tHq_privateUL18"      , "tHq_privateUL17"      , "tHq_privateUL16"      , "tHq_privateUL16APV", "tHq_central2022", "tHq_private2022"],
-            "tttt"  : ["tttt_centralUL16APV"   ,"tttt_centralUL16"   ,"tttt_centralUL17","tttt_centralUL18", "tttt_privateUL18"     , "tttt_privateUL17"     , "tttt_privateUL16"     , "tttt_privateUL16APV", "TTTT_central2022", "TTTT_central2022EE"],
+            "ttlnu" : ["ttW_centralUL16APV"    ,"ttW_centralUL16"    ,"ttW_centralUL17" ,"ttW_centralUL18" , "ttlnuJet_privateUL18" , "ttlnuJet_privateUL17" , "ttlnuJet_privateUL16" , "ttlnuJet_privateUL16APV", "ttW_central2022", "ttW_central2022EE", "ttW_central2023", "ttW_central2023BPix", "ttlnu_private2022", "ttlnu_private2022EE", "ttlnu_private2023", "ttlnu_private2023BPix"],
+            "ttll"  : ["ttZ_centralUL16APV"    ,"ttZ_centralUL16"    ,"ttZ_centralUL17" ,"ttZ_centralUL18" , "ttllJet_privateUL18"  , "ttllJet_privateUL17"  , "ttllJet_privateUL16"  , "ttllJet_privateUL16APV",  "TTLL_MLL-50_central2022", "TTLL_MLL-4to50_central2022" ,"TTLL_MLL-50_central2022EE", "TTLL_MLL-4to50_central2022EE", "TTLL_MLL-50_central2023", "TTLL_MLL-4to50_central2023", "TTLL_MLL-50_central2023BPix", "TTLL_MLL-4to50_central2023BPix", "ttll_private2022", "ttll_private2022EE", "ttll_private2023", "ttll_private2023BPix"],
+            "ttH"   : ["ttHJet_centralUL16APV" ,"ttHJet_centralUL16" ,"ttH_centralUL17" ,"ttH_centralUL18" , "ttHJet_privateUL18"   , "ttHJet_privateUL17"   , "ttHJet_privateUL16"   , "ttHJet_privateUL16APV", "ttHnobb-1Jets_central2022",  "ttHnobb-1Jets_central2022EE", "ttHnobb-1Jets_central2023", "ttHnobb-1Jets_central2023BPix", "ttH_private2022", "ttH_private2022EE", "ttH_private2023", "ttH_private2023BPix"],
+            "tllq"  : ["tZq_centralUL16APV"    ,"tZq_centralUL16"    ,"tZq_centralUL17" ,"tZq_centralUL18" , "tllq_privateUL18"     , "tllq_privateUL17"     , "tllq_privateUL16"     , "tllq_privateUL16APV", "tZq_central2022", "tZq_central2022EE", "tZq_central2023", "tZq_central2023BPix", "tllq_private2022", "tllq_private2022EE", "tllq_private2023", "tllq_private2023BPix"],
+            "tHq"   : ["tHq_centralUL16APV"    ,"tHq_centralUL16"    ,"tHq_centralUL17" ,"tHq_centralUL18" , "tHq_privateUL18"      , "tHq_privateUL17"      , "tHq_privateUL16"      , "tHq_privateUL16APV", "tHq_central2022", "tHq_central2022EE", "tHq_central2023", "tHq_central2023BPix", "tHq_private2022", "tHq_private2022EE", "tHq_private2023", "tHq_private2023BPix"],
+            "tttt"  : ["tttt_centralUL16APV"   ,"tttt_centralUL16"   ,"tttt_centralUL17","tttt_centralUL18", "tttt_privateUL18"     , "tttt_privateUL17"     , "tttt_privateUL16"     , "tttt_privateUL16APV", "TTTT_central2022", "TTTT_central2022EE", "TTTT_central2023", "TTTT_central2023BPix", "tttt_private2022", "tttt_private2022EE", "tttt_private2023", "tttt_private2023BPix"],
 
             "flips" : [
                 canonicalize_process_name(proc_name)
@@ -67,7 +67,7 @@ class YieldTools():
                     "NonPrompt2023BPix",
                 )
             ],
-            "conv"  : ["TTGamma_centralUL16"  ,"TTGamma_centralUL16APV"  ,"TTGamma_centralUL17"  ,"TTGamma_centralUL18"  ,"TTGamma_central2022"],
+            "conv"  : ["TTGamma_centralUL16"  ,"TTGamma_centralUL16APV"  ,"TTGamma_centralUL17"  ,"TTGamma_centralUL18"  ,"TTGamma_central2022", "TTGamma_central2022EE", "TTGamma_central2023", "TTGamma_central2023BPix"],
             "WW"    : ["WWTo2L2Nu_centralUL16","WWTo2L2Nu_centralUL16APV","WWTo2L2Nu_centralUL17","WWTo2L2Nu_centralUL18","WWTo2L2Nu_central2022", "WWTo2L2Nu_central2022EE", "WWTo2L2Nu_central2023", "WWTo2L2Nu_central2023BPix"],
             "WZ"    : ["WZTo3LNu_centralUL16" ,"WZTo3LNu_centralUL16APV" ,"WZTo3LNu_centralUL17" ,"WZTo3LNu_centralUL18","WZTo3LNu_central2022","WZTo3LNu_central2022EE", "WZTo3LNu_central2023", "WZTo3LNu_central2023BPix"],
             "ZZ"    : ["ZZTo4L_centralUL16"   ,"ZZTo4L_centralUL16APV"   ,"ZZTo4L_centralUL17"   ,"ZZTo4L_centralUL18"   ,"ZZTo4L_central2022", "ZZTo4L_central2022EE",  "ZZTo4L_central2023",  "ZZTo4L_central2023BPix"],
@@ -77,11 +77,11 @@ class YieldTools():
             "ZZZ"   : ["ZZZ_centralUL16"      ,"ZZZ_centralUL16APV"      ,"ZZZ_centralUL17"      ,"ZZZ_centralUL18"      ,"ZZZ_central2022","ZZZ_central2022EE", "ZZZ_central2023", "ZZZ_central2023BPix"],
             "tWZ"   : ["TWZToLL_centralUL16"  ,"TWZToLL_centralUL16APV"  ,"TWZToLL_centralUL17"  ,"TWZToLL_centralUL18"  ,"TWZToLL_central2022", "TWZ_TtoLNu_Wto2Q_Zto2L_central2022","TWZ_TtoLNu_Wto2Q_Zto2L_central2022EE", "TWZ_TtoLNu_Wto2Q_Zto2L_central2023", "TWZ_TtoLNu_Wto2Q_Zto2L_central2023BPix"],
 
-            "ttZlowMll"   : ["TTZToLL_M1to10_centralUL16"  ,"TTZToLL_M1to10_centralUL16APV"  ,"TTZToLL_M1to10_centralUL17"  ,"TTZToLL_M1to10_centralUL18"  ,"TTZToLL_M1to10_central2022"],
+            "ttZlowMll"   : ["TTZToLL_M1to10_centralUL16"  ,"TTZToLL_M1to10_centralUL16APV"  ,"TTZToLL_M1to10_centralUL17"  ,"TTZToLL_M1to10_centralUL18"  ,"TTZToLL_M1to10_central2022", "TTZToLL_M1to10_central2022EE", "TTZToLL_M1to10_central2023", "TTZToLL_M1to10_central2023BPix"],
             "ttbarll" : ["TTTo2L2Nu_centralUL16", "TTTo2L2Nu_centralUL16APV", "TTTo2L2Nu_centralUL17", "TTTo2L2Nu_centralUL18", "TTTo2L2Nu_central2022", "TTto2L2Nu_central2022EE", "TTto2L2Nu_central2023", "TTto2L2Nu_central2023BPix"],
-            "ttbarsl" : ["TTToSemiLeptonic_centralUL16", "TTToSemiLeptonic_centralUL16APV", "TTToSemiLeptonic_centralUL17", "TTToSemiLeptonic_centralUL18","TTToSemiLeptonic_central2022"],
+            "ttbarsl" : ["TTToSemiLeptonic_centralUL16", "TTToSemiLeptonic_centralUL16APV", "TTToSemiLeptonic_centralUL17", "TTToSemiLeptonic_centralUL18","TTToSemiLeptonic_central2022", "TTToSemiLeptonic_central2022EE", "TTToSemiLeptonic_central2023", "TTToSemiLeptonic_central2023BPix"],
 
-            "data"   : ["dataUL16","dataUL16APV","dataUL17","dataUL18","data2022"],
+            "data"   : ["dataUL16","dataUL16APV","dataUL17","dataUL18","data2022", "data2022EE", "data2023", "data2023BPix"],
         }
 
 

--- a/topeft/params/cr_sr_plots_metadata.yml
+++ b/topeft/params/cr_sr_plots_metadata.yml
@@ -1,386 +1,479 @@
 DATA_ERR_OPS:
   linestyle: none
-  marker: '.'
+  marker: .
   markersize: 10.0
   color: k
   elinewidth: 1
 MC_ERROR_OPS:
-  label: 'Stat. Unc.'
-  hatch: '////'
+  label: Stat. Unc.
+  hatch: ////
   facecolor: none
-  edgecolor: [0,0,0,0.5]
+  edgecolor:
+  - 0
+  - 0
+  - 0
+  - 0.5
   linewidth: 0
 DATA_DRIVEN_PREFIXES:
-  - nonprompt
-  - flips
+- nonprompt
+- flips
 CR_CHAN_DICT:
   cr_2los_Z:
-    - 2los_ee_CRZ_0j
-    - 2los_mm_CRZ_0j
+  - 2los_ee_CRZ_0j
+  - 2los_mm_CRZ_0j
   cr_2los_Z_ee:
-    - 2los_ee_CRZ_0j
+  - 2los_ee_CRZ_0j
   cr_2los_Z_mm:
-    - 2los_mm_CRZ_0j
+  - 2los_mm_CRZ_0j
   cr_2los_tt:
-    - 2los_em_CRtt_2j
+  - 2los_em_CRtt_2j
   cr_2lss:
-    - 2lss_ee_CR_1j
-    - 2lss_em_CR_1j
-    - 2lss_mm_CR_1j
-    - 2lss_ee_CR_2j
-    - 2lss_em_CR_2j
-    - 2lss_mm_CR_2j
-    - 2lss_ee_CR_3j
-    - 2lss_em_CR_3j
-    - 2lss_mm_CR_3j
+  - 2lss_ee_CR_1j
+  - 2lss_em_CR_1j
+  - 2lss_mm_CR_1j
+  - 2lss_ee_CR_2j
+  - 2lss_em_CR_2j
+  - 2lss_mm_CR_2j
+  - 2lss_ee_CR_3j
+  - 2lss_em_CR_3j
+  - 2lss_mm_CR_3j
   cr_2lss_ee:
-    - 2lss_ee_CR_1j
-    - 2lss_ee_CR_2j
-    - 2lss_ee_CR_3j
+  - 2lss_ee_CR_1j
+  - 2lss_ee_CR_2j
+  - 2lss_ee_CR_3j
   cr_2lss_em:
-    - 2lss_em_CR_1j
-    - 2lss_em_CR_2j
-    - 2lss_em_CR_3j
+  - 2lss_em_CR_1j
+  - 2lss_em_CR_2j
+  - 2lss_em_CR_3j
   cr_2lss_mm:
-    - 2lss_mm_CR_1j
-    - 2lss_mm_CR_2j
-    - 2lss_mm_CR_3j
+  - 2lss_mm_CR_1j
+  - 2lss_mm_CR_2j
+  - 2lss_mm_CR_3j
   cr_2lss_flip:
-    - 2lss_ee_CRflip_3j
+  - 2lss_ee_CRflip_3j
   cr_3l:
-    - 3l_eee_CR_0j
-    - 3l_eem_CR_0j
-    - 3l_emm_CR_0j
-    - 3l_mmm_CR_0j
-    - 3l_eee_CR_1j
-    - 3l_eem_CR_1j
-    - 3l_emm_CR_1j
-    - 3l_mmm_CR_1j
+  - 3l_eee_CR_0j
+  - 3l_eem_CR_0j
+  - 3l_emm_CR_0j
+  - 3l_mmm_CR_0j
+  - 3l_eee_CR_1j
+  - 3l_eem_CR_1j
+  - 3l_emm_CR_1j
+  - 3l_mmm_CR_1j
   cr_3l_eee:
-    - 3l_eee_CR_0j
-    - 3l_eee_CR_1j
+  - 3l_eee_CR_0j
+  - 3l_eee_CR_1j
   cr_3l_mixed:
-    - 3l_eem_CR_0j
-    - 3l_emm_CR_0j
-    - 3l_eem_CR_1j
-    - 3l_emm_CR_1j
+  - 3l_eem_CR_0j
+  - 3l_emm_CR_0j
+  - 3l_eem_CR_1j
+  - 3l_emm_CR_1j
   cr_3l_mmm:
-    - 3l_mmm_CR_0j
-    - 3l_mmm_CR_1j
+  - 3l_mmm_CR_0j
+  - 3l_mmm_CR_1j
   cr_2los_1tau_Ftau:
-    - 2los_ee_1tau_Ftau_2j
-    - 2los_ee_1tau_Ftau_3j
-    - 2los_ee_1tau_Ftau_4j
-    - 2los_em_1tau_Ftau_2j
-    - 2los_em_1tau_Ftau_3j
-    - 2los_em_1tau_Ftau_4j
-    - 2los_mm_1tau_Ftau_2j
-    - 2los_mm_1tau_Ftau_3j
-    - 2los_mm_1tau_Ftau_4j
+  - 2los_ee_1tau_Ftau_2j
+  - 2los_ee_1tau_Ftau_3j
+  - 2los_ee_1tau_Ftau_4j
+  - 2los_em_1tau_Ftau_2j
+  - 2los_em_1tau_Ftau_3j
+  - 2los_em_1tau_Ftau_4j
+  - 2los_mm_1tau_Ftau_2j
+  - 2los_mm_1tau_Ftau_3j
+  - 2los_mm_1tau_Ftau_4j
   cr_2los_1tau_Ttau:
-    - 2los_ee_1tau_Ttau_2j
-    - 2los_ee_1tau_Ttau_3j
-    - 2los_ee_1tau_Ttau_4j
-    - 2los_em_1tau_Ttau_2j
-    - 2los_em_1tau_Ttau_3j
-    - 2los_em_1tau_Ttau_4j
-    - 2los_mm_1tau_Ttau_2j
-    - 2los_mm_1tau_Ttau_3j
-    - 2los_mm_1tau_Ttau_4j
+  - 2los_ee_1tau_Ttau_2j
+  - 2los_ee_1tau_Ttau_3j
+  - 2los_ee_1tau_Ttau_4j
+  - 2los_em_1tau_Ttau_2j
+  - 2los_em_1tau_Ttau_3j
+  - 2los_em_1tau_Ttau_4j
+  - 2los_mm_1tau_Ttau_2j
+  - 2los_mm_1tau_Ttau_3j
+  - 2los_mm_1tau_Ttau_4j
   cr_1l_1tau:
-    - 1l_e_1tau_CR_2j
-    - 1l_e_1tau_CR_3j
-    - 1l_e_1tau_CR_4j
-    - 1l_m_1tau_CR_2j
-    - 1l_m_1tau_CR_3j
-    - 1l_m_1tau_CR_4j
+  - 1l_e_1tau_CR_2j
+  - 1l_e_1tau_CR_3j
+  - 1l_e_1tau_CR_4j
+  - 1l_m_1tau_CR_2j
+  - 1l_m_1tau_CR_3j
+  - 1l_m_1tau_CR_4j
   cr_1l_1tau_e:
-    - 1l_e_1tau_CR_2j
-    - 1l_e_1tau_CR_3j
-    - 1l_e_1tau_CR_4j
+  - 1l_e_1tau_CR_2j
+  - 1l_e_1tau_CR_3j
+  - 1l_e_1tau_CR_4j
   cr_1l_1tau_m:
-    - 1l_m_1tau_CR_2j
-    - 1l_m_1tau_CR_3j
-    - 1l_m_1tau_CR_4j
+  - 1l_m_1tau_CR_2j
+  - 1l_m_1tau_CR_3j
+  - 1l_m_1tau_CR_4j
   cr_dy_tautau:
-    - 1l_e_dy_tautau_CR_2j
-    - 1l_e_dy_tautau_CR_3j
-    - 1l_e_dy_tautau_CR_4j
-    - 1l_m_dy_tautau_CR_2j
-    - 1l_m_dy_tautau_CR_3j
-    - 1l_m_dy_tautau_CR_4j
+  - 1l_e_dy_tautau_CR_2j
+  - 1l_e_dy_tautau_CR_3j
+  - 1l_e_dy_tautau_CR_4j
+  - 1l_m_dy_tautau_CR_2j
+  - 1l_m_dy_tautau_CR_3j
+  - 1l_m_dy_tautau_CR_4j
   cr_dy_tautau_e:
-    - 1l_e_dy_tautau_CR_2j
-    - 1l_e_dy_tautau_CR_3j
-    - 1l_e_dy_tautau_CR_4j
+  - 1l_e_dy_tautau_CR_2j
+  - 1l_e_dy_tautau_CR_3j
+  - 1l_e_dy_tautau_CR_4j
   cr_dy_tautau_m:
-    - 1l_m_dy_tautau_CR_2j
-    - 1l_m_dy_tautau_CR_3j
-    - 1l_m_dy_tautau_CR_4j
+  - 1l_m_dy_tautau_CR_2j
+  - 1l_m_dy_tautau_CR_3j
+  - 1l_m_dy_tautau_CR_4j
 SR_CHAN_DICT:
   2lss_SR:
-    - 2lss_4t_m_4j
-    - 2lss_4t_m_5j
-    - 2lss_4t_m_6j
-    - 2lss_4t_m_7j
-    - 2lss_4t_p_4j
-    - 2lss_4t_p_5j
-    - 2lss_4t_p_6j
-    - 2lss_4t_p_7j
-    - 2lss_m_4j
-    - 2lss_m_5j
-    - 2lss_m_6j
-    - 2lss_m_7j
-    - 2lss_p_4j
-    - 2lss_p_5j
-    - 2lss_p_6j
-    - 2lss_p_7j
+  - 2lss_4t_m_4j
+  - 2lss_4t_m_5j
+  - 2lss_4t_m_6j
+  - 2lss_4t_m_7j
+  - 2lss_4t_p_4j
+  - 2lss_4t_p_5j
+  - 2lss_4t_p_6j
+  - 2lss_4t_p_7j
+  - 2lss_m_4j
+  - 2lss_m_5j
+  - 2lss_m_6j
+  - 2lss_m_7j
+  - 2lss_p_4j
+  - 2lss_p_5j
+  - 2lss_p_6j
+  - 2lss_p_7j
   3l_offZ_SR:
-    - 3l_m_offZ_1b_2j
-    - 3l_m_offZ_1b_3j
-    - 3l_m_offZ_1b_4j
-    - 3l_m_offZ_1b_5j
-    - 3l_m_offZ_2b_2j
-    - 3l_m_offZ_2b_3j
-    - 3l_m_offZ_2b_4j
-    - 3l_m_offZ_2b_5j
-    - 3l_p_offZ_1b_2j
-    - 3l_p_offZ_1b_3j
-    - 3l_p_offZ_1b_4j
-    - 3l_p_offZ_1b_5j
-    - 3l_p_offZ_2b_2j
-    - 3l_p_offZ_2b_3j
-    - 3l_p_offZ_2b_4j
-    - 3l_p_offZ_2b_5j
+  - 3l_m_offZ_1b_2j
+  - 3l_m_offZ_1b_3j
+  - 3l_m_offZ_1b_4j
+  - 3l_m_offZ_1b_5j
+  - 3l_m_offZ_2b_2j
+  - 3l_m_offZ_2b_3j
+  - 3l_m_offZ_2b_4j
+  - 3l_m_offZ_2b_5j
+  # - 3l_m_offZ_high_1b_1j
+  # - 3l_m_offZ_high_1b_2j
+  # - 3l_m_offZ_high_1b_3j
+  # - 3l_m_offZ_high_1b_4j
+  # - 3l_m_offZ_high_1b_5j
+  # - 3l_m_offZ_high_2b_1j
+  # - 3l_m_offZ_high_2b_2j
+  # - 3l_m_offZ_high_2b_3j
+  # - 3l_m_offZ_high_2b_4j
+  # - 3l_m_offZ_high_2b_5j
+  # - 3l_m_offZ_low_1b_1j
+  # - 3l_m_offZ_low_1b_2j
+  # - 3l_m_offZ_low_1b_3j
+  # - 3l_m_offZ_low_1b_4j
+  # - 3l_m_offZ_low_1b_5j
+  # - 3l_m_offZ_low_2b_1j
+  # - 3l_m_offZ_low_2b_2j
+  # - 3l_m_offZ_low_2b_3j
+  # - 3l_m_offZ_low_2b_4j
+  # - 3l_m_offZ_low_2b_5j
+  # - 3l_m_offZ_none_1b_1j
+  # - 3l_m_offZ_none_1b_2j
+  # - 3l_m_offZ_none_1b_3j
+  # - 3l_m_offZ_none_1b_4j
+  # - 3l_m_offZ_none_1b_5j
+  # - 3l_m_offZ_none_2b_1j
+  # - 3l_m_offZ_none_2b_2j
+  # - 3l_m_offZ_none_2b_3j
+  # - 3l_m_offZ_none_2b_4j
+  # - 3l_m_offZ_none_2b_5j
+  - 3l_p_offZ_1b_2j
+  - 3l_p_offZ_1b_3j
+  - 3l_p_offZ_1b_4j
+  - 3l_p_offZ_1b_5j
+  - 3l_p_offZ_2b_2j
+  - 3l_p_offZ_2b_3j
+  - 3l_p_offZ_2b_4j
+  - 3l_p_offZ_2b_5j
+  # - 3l_p_offZ_high_1b_1j
+  # - 3l_p_offZ_high_1b_2j
+  # - 3l_p_offZ_high_1b_3j
+  # - 3l_p_offZ_high_1b_4j
+  # - 3l_p_offZ_high_1b_5j
+  # - 3l_p_offZ_high_2b_1j
+  # - 3l_p_offZ_high_2b_2j
+  # - 3l_p_offZ_high_2b_3j
+  # - 3l_p_offZ_high_2b_4j
+  # - 3l_p_offZ_high_2b_5j
+  # - 3l_p_offZ_low_1b_1j
+  # - 3l_p_offZ_low_1b_2j
+  # - 3l_p_offZ_low_1b_3j
+  # - 3l_p_offZ_low_1b_4j
+  # - 3l_p_offZ_low_1b_5j
+  # - 3l_p_offZ_low_2b_1j
+  # - 3l_p_offZ_low_2b_2j
+  # - 3l_p_offZ_low_2b_3j
+  # - 3l_p_offZ_low_2b_4j
+  # - 3l_p_offZ_low_2b_5j
+  # - 3l_p_offZ_none_1b_1j
+  # - 3l_p_offZ_none_1b_2j
+  # - 3l_p_offZ_none_1b_3j
+  # - 3l_p_offZ_none_1b_4j
+  # - 3l_p_offZ_none_1b_5j
+  # - 3l_p_offZ_none_2b_1j
+  # - 3l_p_offZ_none_2b_2j
+  # - 3l_p_offZ_none_2b_3j
+  # - 3l_p_offZ_none_2b_4j
+  # - 3l_p_offZ_none_2b_5j
   3l_onZ_SR:
-    - 3l_onZ_1b_2j
-    - 3l_onZ_1b_3j
-    - 3l_onZ_1b_4j
-    - 3l_onZ_1b_5j
-    - 3l_onZ_2b_2j
-    - 3l_onZ_2b_3j
-    - 3l_onZ_2b_4j
-    - 3l_onZ_2b_5j
+  - 3l_onZ_1b_1j
+  - 3l_onZ_1b_2j
+  - 3l_onZ_1b_3j
+  - 3l_onZ_1b_4j
+  - 3l_onZ_1b_5j
+  - 3l_onZ_2b_1j
+  - 3l_onZ_2b_2j
+  - 3l_onZ_2b_3j
+  - 3l_onZ_2b_4j
+  - 3l_onZ_2b_5j
   4l_SR:
-    - 4l_2j
-    - 4l_3j
-    - 4l_4j
-  4l_2j:
-    - 4l_2j
-  4l_3j:
-    - 4l_3j
-  4l_4j:
-    - 4l_4j
+  - 4l_2j
+  - 4l_3j
+  - 4l_4j
   2lss_1tau_onZ:
-    - 2lss_m_1tau_onZ_3j
-    - 2lss_m_1tau_onZ_4j
-    - 2lss_m_1tau_onZ_5j
-    - 2lss_m_1tau_onZ_6j
-    - 2lss_p_1tau_onZ_3j
-    - 2lss_p_1tau_onZ_4j
-    - 2lss_p_1tau_onZ_5j
-    - 2lss_p_1tau_onZ_6j
+  - 2lss_m_1tau_onZ_3j
+  - 2lss_m_1tau_onZ_4j
+  - 2lss_m_1tau_onZ_5j
+  - 2lss_m_1tau_onZ_6j
+  - 2lss_p_1tau_onZ_3j
+  - 2lss_p_1tau_onZ_4j
+  - 2lss_p_1tau_onZ_5j
+  - 2lss_p_1tau_onZ_6j
   2lss_1tau_offZ:
-    - 2lss_m_1tau_offZ_3j
-    - 2lss_m_1tau_offZ_4j
-    - 2lss_m_1tau_offZ_5j
-    - 2lss_m_1tau_offZ_6j
-    - 2lss_p_1tau_offZ_3j
-    - 2lss_p_1tau_offZ_4j
-    - 2lss_p_1tau_offZ_5j
-    - 2lss_p_1tau_offZ_6j
+  - 2lss_m_1tau_offZ_3j
+  - 2lss_m_1tau_offZ_4j
+  - 2lss_m_1tau_offZ_5j
+  - 2lss_m_1tau_offZ_6j
+  - 2lss_p_1tau_offZ_3j
+  - 2lss_p_1tau_offZ_4j
+  - 2lss_p_1tau_offZ_5j
+  - 2lss_p_1tau_offZ_6j
   2los_onZ_1tau:
-    - 2los_onZ_1tau_5j
-  3l_1tau_1b:
-    - 3l_1tau_1b_2j
-    - 3l_1tau_1b_3j
-    - 3l_1tau_1b_4j
-    - 3l_1tau_1b_5j
-  3l_1tau_2b:
-    - 3l_1tau_2b_2j
-    - 3l_1tau_2b_3j
-    - 3l_1tau_2b_4j
-    - 3l_1tau_2b_5j
+  - 2los_onZ_1tau_5j
+  2lss_1tau:
+  - 2lss_m_1tau_onZ_3j
+  - 2lss_p_1tau_offZ_3j
+  - 2lss_m_1tau_offZ_3j
+  - 2lss_p_1tau_onZ_3j
+  - 2lss_m_1tau_onZ_4j
+  - 2lss_p_1tau_offZ_4j
+  - 2lss_m_1tau_offZ_4j
+  - 2lss_p_1tau_onZ_4j
+  - 2lss_m_1tau_onZ_5j
+  - 2lss_p_1tau_offZ_5j
+  - 2lss_m_1tau_offZ_5j
+  - 2lss_p_1tau_onZ_5j
+  - 2lss_m_1tau_onZ_6j
+  - 2lss_p_1tau_offZ_6j
+  - 2lss_m_1tau_offZ_6j
+  - 2lss_p_1tau_onZ_6j
+  3l_offZ_fwd:
+  - 3l_m_offZ_1b_fwd_1j
+  - 3l_p_offZ_1b_fwd_1j
+  - 3l_m_offZ_2b_fwd_1j
+  - 3l_p_offZ_2b_fwd_1j
+  - 3l_m_offZ_1b_fwd_2j
+  - 3l_p_offZ_1b_fwd_2j
+  - 3l_m_offZ_2b_fwd_2j
+  - 3l_p_offZ_2b_fwd_2j
+  - 3l_m_offZ_1b_fwd_3j
+  - 3l_p_offZ_1b_fwd_3j
+  - 3l_m_offZ_2b_fwd_3j
+  - 3l_p_offZ_2b_fwd_3j
+  - 3l_m_offZ_1b_fwd_4j
+  - 3l_p_offZ_1b_fwd_4j
+  - 3l_m_offZ_2b_fwd_4j
+  - 3l_p_offZ_2b_fwd_4j
+  2lss:
+  - 2lss_p_4j
+  - 2lss_m_4j
+  - 2lss_4t_p_4j
+  - 2lss_4t_m_4j
+  - 2lss_p_5j
+  - 2lss_m_5j
+  - 2lss_4t_p_5j
+  - 2lss_4t_m_5j
+  - 2lss_p_6j
+  - 2lss_m_6j
+  - 2lss_4t_p_6j
+  - 2lss_4t_m_6j
+  - 2lss_p_7j
+  - 2lss_m_7j
+  - 2lss_4t_p_7j
+  - 2lss_4t_m_7j
+  2lss_fwd:
+  - 2lss_fwd_m_4j
+  - 2lss_fwd_m_5j
+  - 2lss_fwd_m_6j
+  - 2lss_fwd_m_7j
+  - 2lss_fwd_p_4j
+  - 2lss_fwd_p_5j
+  - 2lss_fwd_p_6j
+  - 2lss_fwd_p_7j
+  3l_1tau:
+  - 3l_1tau_1b_1j
+  - 3l_1tau_1b_2j
+  - 3l_1tau_1b_3j
+  - 3l_1tau_1b_4j
+  - 3l_1tau_1b_5j
+  - 3l_1tau_2b_1j
+  - 3l_1tau_2b_2j
+  - 3l_1tau_2b_3j
+  - 3l_1tau_2b_4j
+  - 3l_1tau_2b_5j
+  3l_onZ_fwd:
+  - 3l_onZ_1b_fwd_1j
+  - 3l_onZ_2b_fwd_1j
+  - 3l_onZ_1b_fwd_2j
+  - 3l_onZ_2b_fwd_2j
+  - 3l_onZ_1b_fwd_3j
+  - 3l_onZ_2b_fwd_3j
+  - 3l_onZ_1b_fwd_4j
+  - 3l_onZ_2b_fwd_4j
 CR_GRP_MAP:
   Data:
     color: black
     patterns:
-      - data
+    - data
   DY:
     color: tab:blue
     patterns:
-      - DY
+    - DY
   Ttbar:
     color: darkgreen
     patterns:
-      - TTTo
-      - TTto
+    - TTTo
+    - TTto
   ZGamma:
     color: tab:orange
     patterns:
-      - ZG
+    - ZG
   Diboson:
     color: tab:cyan
     patterns:
-      - WWTo2L2Nu
-      - ZZTo4L
-      - WZTo3LNu
-      - WZto3LNu
-      - ZZTo4mu
-      - ZZTo4tau
-      - ZZTo4e
-      - ZZTo2mu2tau
-      - ZZTo2e2tau
-      - ZZTo2e2mu
+    - WWTo2L2Nu
+    - ZZTo4L
+    - WZTo3LNu
+    - WZto3LNu
+    - ZZTo4mu
+    - ZZTo4tau
+    - ZZTo4e
+    - ZZTo2mu2tau
+    - ZZTo2e2tau
+    - ZZTo2e2mu
   Triboson:
     color: tab:purple
     patterns:
-      - WWW
-      - WWZ
-      - WZZ
-      - ZZZ
-  'Single top':
+    - WWW
+    - WWZ
+    - WZZ
+    - ZZZ
+  Single top:
     color: tab:pink
     patterns:
-      - ST
-      - tW
-      - tbarW
-      - TZQB-Zto2L
+    - ST
+    - tW
+    - tbarW
+    - TZQB-Zto2L
   tWZ:
     color: tab:gray
     patterns:
-      - TWZ
+    - TWZ
   Singleboson:
     color: tan
     patterns:
-      - WJets
+    - WJets
   Conv:
     color: mediumseagreen
     patterns:
-      - TTG
+    - TTG
   Nonprompt:
     color: tab:red
     patterns:
-      - nonprompt
+    - nonprompt
   Flips:
     color: brown
     patterns:
-      - flips
+    - flips
   Signal:
     color: yellowgreen
     patterns:
-      - ttH
-      - ttlnu
-      - TTLL
-      - ttll
-      - tllq
-      - tHq
-      - tttt
-      - TTZToLL_M1to10
-      - TTTT
-      - ttLNu
-  # WWTo2L2Nu:
-  #   color: brown
-  #   patterns:
-  #     - WWTo2L2Nu
-  # ZZTo4L:
-  #   color: goldenrod
-  #   patterns:
-  #     - ZZTo4L
-  # WZTo3LNu:
-  #   color: yellow
-  #   patterns:
-  #     - WZto3LNu
-  #     - WZTo3LNu
-  # ZZTo4mu:
-  #   color: darkviolet
-  #   patterns:
-  #     - ZZTo4mu
-  # ZZTo4tau:
-  #   color: olive
-  #   patterns:
-  #     - ZZTo4tau
-  # ZZTo4e:
-  #   color: coral
-  #   patterns:
-  #     - ZZTo4e
-  # ZZTo2mu2tau:
-  #   color: navy
-  #   patterns:
-  #     - ZZTo2mu2tau
-  # ZZTo2e2tau:
-  #   color: yellowgreen
-  #   patterns:
-  #     - ZZTo2e2tau
-  # ZZTo2e2mu:
-  #   color: aquamarine
-  #   patterns:
-  #     - ZZTo2e2mu
+    - ttH
+    - ttlnu
+    - TTLL
+    - ttll
+    - tllq
+    - tHq
+    - tttt
+    - TTZToLL_M1to10
+    - TTTT
+    - ttLNu
 SR_GRP_MAP:
   Data:
     color: black
     patterns:
-      - data
+    - data
   Nonprompt:
     color: tab:red
     patterns:
-      - nonprompt
+    - nonprompt
   Flips:
     color: brown
     patterns:
-      - flips
+    - flips
   ttH:
     color: tab:orange
     patterns:
-      - ttH
+    - ttH
   ttlnu:
     color: tab:cyan
     patterns:
-      - ttlnu
+    - ttlnu
   ttll:
     color: tab:purple
     patterns:
-      - ttll
-      - TTZToLL_M1to10
-      - TTToSemiLeptonic
-      - TTTo2L2Nu
+    - ttll
+    - TTZToLL_M1to10
+    - TTToSemiLeptonic
+    - TTTo2L2Nu
   tXq:
     color: tab:pink
     patterns:
-      - tllq
-      - tHq
+    - tllq
+    - tHq
   tttt:
     color: tan
     patterns:
-      - tttt
+    - tttt
   Conv:
     color: mediumseagreen
     patterns:
-      - TTG
+    - TTG
   Triboson:
     color: tab:purple
     patterns:
-      - WWW
-      - WWZ
-      - WZZ
-      - ZZZ
+    - WWW
+    - WWZ
+    - WZZ
+    - ZZZ
   tWZ:
     color: tab:gray
     patterns:
-      - TWZ
+    - TWZ
   Diboson:
     color: tab:cyan
     patterns:
-      - WWTo2L2Nu
-      - ZZTo4L
-      - WZTo3LNu
-      - WZto3LNu
-      - ZZTo4mu
-      - ZZTo4tau
-      - ZZTo4e
-      - ZZTo2mu2tau
-      - ZZTo2e2tau
-      - ZZTo2e2mu
+    - WWTo2L2Nu
+    - ZZTo4L
+    - WZTo3LNu
+    - WZto3LNu
+    - ZZTo4mu
+    - ZZTo4tau
+    - ZZTo4e
+    - ZZTo2mu2tau
+    - ZZTo2e2tau
+    - ZZTo2e2mu
 WCPT_EXAMPLE:
   ctW: -0.74
   ctZ: -0.86
@@ -409,26 +502,46 @@ WCPT_EXAMPLE:
   cQt8: -2.89
   cQt1: -1.24
 LUMI_COM_PAIRS:
-  '2016': ['35.9', '13']
-  '2016APV': ['19.5', '13']
-  '2017': ['41.5', '13']
-  '2018': ['59.8', '13']
-  '2022': ['7.98', '13.6']
-  '2022EE': ['26.67', '13.6']
-  '2023': ['17.79', '13.6']
-  '2023BPix': ['9.451', '13.6']
+  '2016':
+  - '35.9'
+  - '13'
+  2016APV:
+  - '19.5'
+  - '13'
+  '2017':
+  - '41.5'
+  - '13'
+  '2018':
+  - '59.8'
+  - '13'
+  '2022':
+  - '7.98'
+  - '13.6'
+  2022EE:
+  - '26.67'
+  - '13.6'
+  '2023':
+  - '17.79'
+  - '13.6'
+  2023BPix:
+  - '9.451'
+  - '13.6'
 PROC_WITHOUT_PDF_RATE_SYST:
-  - tttt
-  - ttll
-  - ttlnu
-  - Triboson
-  - tWZ
-  - convs
+- tttt
+- ttll
+- ttlnu
+- Triboson
+- tWZ
+- convs
 STACKED_RATIO_STYLE:
   defaults:
     figure:
-      figsize: [10, 8]
-      height_ratios: [4, 1]
+      figsize:
+      - 10
+      - 8
+      height_ratios:
+      - 4
+      - 1
       hspace: 0.07
     cms:
       fontsize: 18.0
@@ -442,14 +555,16 @@ STACKED_RATIO_STYLE:
       spine_width: 1.0
       y_offset: -0.07
       offset_fontsize: 18
-      ratio_label: "Ratio"
+      ratio_label: Ratio
       ratio_label_fontsize: 18
       ratio_label_margin: 0.002
       ticklabel_format:
         style: scientific
-        scilimits: [0, 6]
+        scilimits:
+        - 0
+        - 6
         useMathText: true
-      overflow_label: ">500"
+      overflow_label: '>500'
       apply_secondary_ticks:
         x: true
         y: true
@@ -460,14 +575,18 @@ STACKED_RATIO_STYLE:
       columnspacing: 0.8
       handletextpad: 0.6
       loc: upper center
-      bbox_to_anchor: [0.5, 1.0]
+      bbox_to_anchor:
+      - 0.5
+      - 1.0
       borderaxespad: 0.15
       top_margin_min: 0.01
       top_margin_scale: 0.25
       overlap_margin: 0.01
     uncertainty_legend:
       loc: upper right
-      bbox_to_anchor: [0.98, 0.98]
+      bbox_to_anchor:
+      - 0.98
+      - 0.98
       fontsize: 10
       ncol: 2
       columnspacing: 1.0
@@ -481,85 +600,57 @@ STACKED_RATIO_STYLE:
   per_region: {}
 REGION_PLOTTING:
   CR:
-    variable_label: "Var name"
+    variable_label: Var name
     skip_sparse_2d: false
-    # channel_mode selects how the plotting loop interprets the channel axis for
-    # every histogram that belongs to this region.  "aggregate" means that the
-    # per-category channel list from CR_CHAN_DICT is collapsed into a single
-    # combined template before the figure is rendered, reproducing the legacy
-    # behaviour where CR plots integrate over all flavours/jet bins inside a
-    # category.  Switching to "per-channel" (used by SR below) leaves the
-    # channel axis intact so that each entry in the region channel map generates
-    # its own figure.  Only these two literal values are supported; any other
-    # string will raise during RegionContext construction.
     channel_mode: aggregate
     skip_variables: []
     channel_transformations:
-      # channel_transformations provides an ordered recipe for rewriting the raw
-      # channel labels that come out of the histogram before any matching is
-      # performed.  The resolved instruction list is the concatenation of:
-      #   * default: unconditional transforms applied to every variable.
-      #   * variables: overrides keyed by the histogram name; the list given for
-      #     "njets" below strips jet-multiplicity suffixes only when we are
-      #     plotting the njets histogram.
-      #   * conditional: rules guarded by a boolean named condition.  Each entry
-      #     specifies a metadata flag (e.g. "not_split_by_lepflav") that maps to
-      #     an evaluator inside YieldTools.  When the condition returns true for
-      #     the histogram currently being processed, its "apply" list is appended
-      #     to the transformation sequence.  In the example we drop lepton-flavour
-      #     suffixes whenever the dataset is not split by flavour, ensuring that
-      #     the CR channel patterns still match the provided CR_CHAN_DICT keys.
       default: []
       variables:
         njets:
-          - njets
+        - njets
       conditional:
-        - when: not_split_by_lepflav
-          apply:
-            - lepflav
+      - when: not_split_by_lepflav
+        apply:
+        - lepflav
     sample_removals:
-      - categories:
-          prefixes:
-            - cr_2los_tt
-            - cr_2los_Z
-        groups:
-          - Nonprompt
+    - categories:
+        prefixes:
+        - cr_2los_tt
+        - cr_2los_Z
+      groups:
+      - Nonprompt
     category_skips:
-      - categories:
-          equals:
-            - cr_2los_Z
-        variable_includes:
-          - j0
-        variable_excludes:
-          - lj0pt
-      - categories:
-          equals:
-            - cr_2lss_flip
-        variable_includes:
-          - j0
-        variable_excludes:
-          - lj0pt
+    - categories:
+        equals:
+        - cr_2los_Z
+      variable_includes:
+      - j0
+      variable_excludes:
+      - lj0pt
+    - categories:
+        equals:
+        - cr_2lss_flip
+      variable_includes:
+      - j0
+      variable_excludes:
+      - lj0pt
     sumw2_remove_signal: true
     sumw2_remove_signal_when_blinded: false
     debug_channel_lists: false
     use_mc_as_data_when_blinded: false
   SR:
-    variable_label: "Variable"
+    variable_label: Variable
     skip_sparse_2d: true
-    # See the CR block above for the semantics of channel_mode.  SR keeps the
-    # channel axis explicit so every channel listed in SR_CHAN_DICT is rendered
-    # individually.
     channel_mode: per-channel
     skip_variables:
-      - ptz
-      - njets
+    - ptz
+    - njets
     channel_transformations:
-      # No SR-specific rewrites are required today, but the same rules described
-      # in the CR section above can be enabled here if future SR plots need to
-      # rename, strip, or otherwise rewrite channel labels before matching them
-      # to SR_CHAN_DICT.
       default: []
-      variables: {}
+      variables:
+        njets:
+        - njets
       conditional: []
     sample_removals: []
     category_skips: []

--- a/topeft/params/params.json
+++ b/topeft/params/params.json
@@ -2,6 +2,7 @@
     "eta_e_cut" : 2.5,
     "eta_m_cut" : 2.4,
     "eta_t_cut" : 2.3,
+    "eta_t_cut_run3" : 2.5,
     "eta_j_cut" : 2.4,
 
     "fo_pt_cut" : 10.0,


### PR DESCRIPTION
## Summary

This PR extends the Run-3 configuration of the topEFT Run-2/Run-3 workflow with:
- a more robust τ_h definition (FO/T WPs, TES/FES/SF tagging, new histograms),
- a cleaned-up and more flexible CR/SR channel metadata model (including `ALL_CH_LST_SR`),
- tooling and tests to keep `ch_lst.json` and `cr_sr_plots_metadata.yml` in sync and to audit zero-yield channels,
- updated Run-3 signal sample configurations and process group mappings,
- and a few Work Queue / performance-oriented tweaks in `run_analysis.py`.


## Motivation

- Run-3 τ_h selections and SFs need to be aligned with the recommended DeepTau working points and DM coverage, while making it easier to inspect FO vs tight τ kinematics.
- CR/SR plotting metadata (`cr_sr_plots_metadata.yml`) and the processor channel definitions (`ch_lst.json`) have grown independently; we need a way to:
  - derive the channel labels the processor actually produces,
  - compare them to the plotting configuration,
  - and fill any gaps in a controlled, scriptable way.
- The per-region group maps for CR/SR plots should:
  - only include processes that actually match a configured group,
  - avoid “mystery” processes silently sneaking into stacks or zero-yield scans,
  - and allow per-region filtering of histograms by grouped processes.
- Run-3 adds a new generation of central and private signal samples (2022EE, 2023, 2023BPix); those must be consistently wired into:
  - input cfgs,
  - yield tools,
  - and plotting group maps.
- Some default analysis settings (chunking, Work Queue tuning, very heavy diagnostic histograms) can be updated to better match current production needs.


## Changes in detail

### 1. Analysis processor: τ_h handling, ALL_CH_LST_SR, and variable naming

**File:** `analysis/topeft_run2/analysis_processor.py`

- **Constructor & flags**
  - Add a new flag `all_analysis` to `AnalysisProcessor.__init__` and store it as `self.all_analysis`.
  - This enables a combined analysis mode that pulls CR/SR channel mappings from `ALL_CH_LST_SR` instead of the legacy `TOP22_006_CH_LST_SR` / FWD / TAU splits.

- **Tau selection refactor (FO/T separation and WPs)**
  - Introduce Run-2/Run-3 dependent tags for τ working points:
    - `tau_fo_tag = "VLoose"` and `tau_T_tag = "Loose"` for Run-2.
    - `tau_fo_tag = "Loose"` and `tau_T_tag = "Medium"` for Run-3.
  - Call:
    - `ApplyTES(year, tau, isData, tau_T_tag)` in the nominal τ_h branch.
    - `ApplyTESSystematic` and `ApplyFESSystematic` with `tau_T_tag` inside the systematics loop.
  - Extend τ ID bookkeeping:
    - Keep `isVLoose` and `isLoose`.
    - Add `isMedium` (via `tauSelection.isMediumTau`).
    - Build `isPresVLoose` and `isPresMedium` using `vsJetWP="Loose"` and `vsJetWP="Medium"` respectively.
    - Define the FO/T “pres” mask via:
      - `tau["isPres"] = tau[f"isPres{tau_fo_tag}"]` (so FO uses VLoose/Loose).
  - Redefine the FO/T τ collections:
    - `tau_fo` := all preselected τ (former “VLoose” set).
    - `tau_T`  := τ with at least the tight WP (`isLoose>0` with the new tag choice).
    - `cleaning_taus` now uses `tau_T`, and `nLtau` is the multiplicity of `tau_T`.
    - `tau0` used for analysis variables corresponds to `tau0_T`.

- **Tau SFs**
  - When not data, attach τ SFs using the tight collection:
    - `AttachTauSF(events, tau_T, year=year, vsJetWP=tau_T_tag)`.
  - Systematics flows are updated consistently to use the new tagged WPs.

- **Tau kinematic variables / histograms**
  - Replace the old single variable:
    - `tau0pt`
  - With two separate observables:
    - `tau0Tpt` (`pt` of leading **tight** τ_h),
    - `tau0Fpt` (`pt` of leading **FO** τ_h).
  - The τ_h branch fills:
    - `varnames["tau0Tpt"] = tau0_T.pt`
    - `varnames["tau0Fpt"] = tau0_fo.pt`
  - `run_analysis.py` hist lists are updated accordingly (see below).

- **CR/SR channel dictionaries**
  - Import of SR categories:
    - Keep existing logic for `offZ_3l_split`, `tau_h_analysis`, and `fwd_analysis`.
    - Add:
      - `elif self.all_analysis: import_sr_cat_dict = select_cat_dict["ALL_CH_LST_SR"]`
  - Import of CR categories:
    - For τ or “all” analyses:
      - `import_cr_cat_dict = select_cat_dict["TAU_CH_LST_CR"]`
    - Otherwise:
      - `import_cr_cat_dict = select_cat_dict["CH_LST_CR"]`
  - Fix indentation of comments so the “skip signal/control regions” logic matches the flags.

  
### 2. Plotting: grouped processes, zero-yield auditing, and blinded data handling

**File:** `analysis/topeft_run2/make_cr_and_sr_plots.py`

- **Process–group helpers**
  - Add `_resolve_grouped_processes(group_map)`:
    - Returns a flat, ordered tuple of process names covered by the region’s `group_map`.
  - Add `_filter_process_axis(histogram, allowed_processes)`:
    - Restricts the `"process"` axis of a histogram to the allowed processes.
    - Safely no-ops when the axis is not present or there is nothing to filter.

- **Zero-yield summary refactor**
  - Existing `_summarize_zero_yield_processes` gains optional:
    - `region_ctx`
    - `variables`
  - When `region_ctx` is provided, delegate to the new:
    - `_summarize_zero_yield_processes_by_variable(...)`.
  - New behaviour:
    - Scan per variable and per channel *and* respect:
      - channel transformations,
      - channel maps,
      - and grouped process selection from `region_ctx.group_map`.
    - Track:
      - `zero_process_total`,
      - `data_driven_zero_total`,
      - `missing_data_driven_prefixes`,
      - errors (e.g. missing process channels, no grouped processes).
    - For each channel/variable entry:
      - expose missing bins and the list of zero-yield processes, with a boolean flag recording if they are data-driven.

- **Zero-yield reporting output**
  - `_emit_zero_yield_summary` now:
    - Prefixes each detailed entry label with `[variable]`, i.e:
      - `region::channel [var]`
    - Prints a consolidated message when both MC and data-like histograms are empty for a given variable.

- **Integration into region context preparation**
  - `_prepare_variable_payload`:
    - After building `hist_mc`, `hist_data`, and optional `hist_mc_sumw2_orig`, apply `_filter_process_axis` with `allowed_processes` derived from `region_ctx.group_map`.
  - `run_plots_for_region`:
    - Hold on to a `summary_region_ctx` (the first built context) for use in the final zero-yield summary.
    - At the end, call `_summarize_zero_yield_processes` with:
      - `region_ctx=summary_region_ctx`
      - `variables=variables`
    - Then emit the summary via `_emit_zero_yield_summary`.

- **Blinded data handling for aggregate plots**
  - For both sparse 2D and 1D stacked plots, introduce a `hist_data_like`:
    - Use:
      - `hist_data_nominal` / integrated data when unblinded or when `use_mc_as_data_when_blinded` is `False`.
      - `hist_mc_nominal` / integrated MC when blinded and `use_mc_as_data_when_blinded` is `True`.
  - Skip plots only when **both** MC and data-like are empty, with a clearer log message:
    - “Empty data-like and MC histogram … skipping plot/2D plot.”

- **Group map behaviour for unmatched samples**
  - `populate_group_map`:
    - Changes unmatched process handling:
      - Previously: create a per-process fallback group.
      - Now: collect all unmatched processes into a list, emit a single warning:
        - “Process names did not match any configured group pattern; skipping: …”
        - and **do not** add them to `group_map`.
  - This ensures:
    - Only known grouped processes appear in stacks and zero-yield summaries.
    - Unmatched processes are explicitly visible via warnings, not silently grouped.

- **Region metadata and channel list semantics**
  - `build_region_context`:
    - `skip_variables` is now always a set built from `region_plot_cfg["skip_variables"]` (when present); the `enable_category_skips` flag no longer suppresses the configuration itself.
  - `run_plots_for_region`:
    - Keeps track of whether split channel labels were restored.
    - Uses `summary_region_ctx` to ensure the zero-yield summary sees consistent grouping and channel maps.


### 3. Tests: group maps, zero-yield scans, and blinded plotting

**File:** `tests/test_make_cr_and_sr_plots.py`

- Add `_find_zero_yield_entry(summary, *, label, variable)` helper to make assertions on the structured zero-yield summary.
- Update existing tests to reflect new group map semantics:
  - Unmatched samples are now skipped from `group_map` (no fallback).
  - Stacked MC totals are compared against the `ttbarSL` contribution explicitly.
- Add a comprehensive suite of tests that cover:
  - SR `njets` channel transforms matching CR behaviour.
  - SR zero-yield summary respecting:
    - njets aggregation rules,
    - missing channel bins,
    - and data-driven patterns.
  - SR/CR zero-yield behaviour with:
    - `skip_variables` in `REGION_PLOTTING`,
    - CR and SR channel maps including missing bins,
    - and correct identification of zero-content data processes.
  - Treatment of unmatched processes in both SR and CR summaries:
    - Warnings are emitted.
    - Unmatched processes do **not** appear in `zero_processes`.
  - Blinded SR aggregate plots using MC when data is empty:
    - `run_plots_for_region` still produces an SR plot as long as MC is non-zero.


### 4. New audit tool for CR/SR channel metadata

**File:** `tools/audit_cr_channels_from_processor.py` (new)

- New standalone CLI to audit and optionally update CR/SR channel dictionaries:

  - Inputs:
    - `--ch-lst` (default `topeft/channels/ch_lst.json`)
    - `--meta-yaml` (default `topeft/params/cr_sr_plots_metadata.yml`)
    - `--regions {CR,SR,both}` (default `both`)
    - `--write-augmented-yaml` plus `--out-meta-yaml <path>` to write an augmented YAML.
  - Logic:
    - For each region (CR, SR) use `REGION_SPECS` to find:
      - Which keys to read from `ch_lst.json` (e.g. `CH_LST_CR`, `TAU_CH_LST_CR`, `CH_LST_SR`, `ALL_CH_LST_SR`, etc.).
      - Whether leptonic flavour splitting is expected (`split_lep_flavor`).
    - Reconstruct the channel labels that the processor can produce via:
      - `_construct_cat_name`, `_jet_cat_to_key`, `_iter_channel_defs`.
    - Compare against YAML keys:
      - For CR: `CR_CHAN_DICT`
      - For SR: `SR_CHAN_DICT`
    - Emit a human-readable report:
      - Labels that exist in the processor but are missing in YAML.
      - Labels that exist in YAML but can never be produced by the processor.

  - Augmentation mode:
    - Do **not** modify `CR_CHAN_DICT`; CR metadata is kept identical to the input file.
    - For SR:
      - Augment `SR_CHAN_DICT` with any missing processor labels.
      - Build semantic SR groups using `SR_TAG_GROUP_RULES`:
        - `2lss_SR`, `2lss_fwd`, `3l_onZ_SR`, `3l_offZ_SR`, `3l_1tau`, `4l_SR`, etc.
      - Drop obsolete fixed-jet 4l groups (`4l_2j`, `4l_3j`, `4l_4j`) in favour of the semantic ones.
      - Apply `_postprocess_sr_groups` to:
        - Rename `3l_fwd` → `3l_onZ_fwd`.
        - Drop redundant base groups already covered by more specific ones (`3l`, `4l`, `2los_1tau`, `2l`).
    - Finally write the augmented YAML to `--out-meta-yaml`.

- All file I/O is guarded with clear error messages and non-zero exit if JSON/YAML is invalid.


### 5. Channel definitions and ALL_CH_LST_SR

**File:** `topeft/channels/ch_lst.json`

- CR side:
  - Restrict 4ℓ CR jet bins:
    - `>4` → `=4` for the `4l` CR category.
  - Split 1ℓ+1τ CRs:
    - `1l_1tau_CR` → `1l_1tau_CRtt` with `appl_lst = ["isSR_1l"]` (no AR).
    - `1l_dy_tautau_CR` → `1l_1tau_CRDY` to better encode the DY -> ττ control region.
  - Introduce and reorganize 2ℓ and 3ℓ CR categories:
    - `2l_CR`, `2l_CRflip`, `2los_CRZ`, `2los_CRtt`, `3l_CR`, etc.
    - Explicit `0tau` / `1tau` / `fwdjet_mask` logical tags in lep channel definitions.

- SR side:
  - Introduce `OFFZ_TAU_SPLIT_CH_LST_SR` to explicitly encode:
    - 3ℓ off-Z, low/high/none `m(ll)`, 1b/2b, with `0tau` and `~fwdjet_mask`.
  - Remove the SR-level 4ℓ subgroups inside `OFFZ_SPLIT_CH_LST_SR` (these are now handled via the unified ALL_CH_LST_SR logic).
  - Add the new unified SR dictionary `ALL_CH_LST_SR`:
    - Contains:
      - Standard 2ℓSS (including 4t and fwd variations with explicit `fwdjet_mask` and `0tau`).
      - 2ℓSS+1τ (onZ/offZ, 3–6 jets).
      - 2ℓOS+1τ (onZ, ≥5 jets).
      - 3ℓ on-Z and off-Z (with 0τ and ~fwdjet_mask).
      - 3ℓ+1τ (1b/2b, any jet bin).
      - 3ℓ fwd on-Z and off-Z SRs (with `fwdjet_mask`).
      - 4ℓ SR.
    - All channels now explicitly carry the tau and fwd tags (e.g. `0tau`, `1tau`, `fwdjet_mask`, `~fwdjet_mask`).

This reorganisation makes the channel space easier to reason about and matches the logic used in the new audit tool and in `make_cr_and_sr_plots`.


### 6. Tau axes, corrections, and object selection

**File:** `topeft/modules/axes.py`

- Replace:
  - `tau0pt` axis with:
    - `tau0Tpt`: leading **tight** hadronic τ.
- Add:
  - `tau0Fpt`: leading **FO** hadronic τ.
- Both are defined with regular binning `(20, 0, 200)` and updated LaTeX labels.

**File:** `topeft/modules/corrections.py`

- **TES / FES phase space**
  - `ApplyTES`:
    - Drop DM 2 from the TES DM mask; use DM ∈ {0,1,10,11} for real τ TES.
  - `ApplyFES`:
    - Extend FES DM coverage to include DM 10 and 11 in addition to 0 and 1.

- **Run-3 DeepTau SFs**
  - When building DeepTau scale factors:
    - Tighten the identification mask to require both VSjet and VSe masks for the VSjet discriminator.
    - Evaluate VSjet SFs as a function of DM rather than pt:
      - `ceval[discr].evaluate(..., "nom", "dm")` / `("up", "dm")` / `("down", "dm")`.
  - Temporarily disable the Run-3 “fake” tau SF component:
    - Replace the dedicated fake SF weights with arrays of ones for now:
      - `new_fake_sf`, `new_fake_sf_up`, `new_fake_sf_down` → 1.0 (per τ).

- **Electron SFs**
  - Drop leftover commented print-based debugging.
  - Keep the behaviour controlled by `looseWP` and `useRun3MVA` unchanged; only clean up diagnostics.

**File:** `topeft/modules/object_selection.py`

- For `run3TauSelection`:
  - Use the Run-3-specific parameter:
    - `get_te_param("eta_t_cut_run3")` instead of the generic `eta_t_cut` for the η acceptance.


### 7. Yield tools: Run-3 process mapping

**File:** `topeft/modules/yield_tools.py`

- Extend `PROC_MAP` to include Run-3 central and private samples for:
  - `ttlnu`, `ttll`, `ttH`, `tllq`, `tHq`, `tttt`:
    - For years: 2022, 2022EE, 2023, 2023BPix.
    - Both central and `*_private{year}` variants are mapped to the same short process names.
  - `conv`:
    - Add `TTGamma` Run-3 entries (2022EE, 2023, 2023BPix).
  - `WW`, `WZ`, `ZZ`, `Triboson`, `tWZ`, `ttZlowMll`, `ttbarll`, `ttbarsl`:
    - Add entries for 2022EE, 2023, 2023BPix where available.
  - `data`:
    - Extend to `data2022EE`, `data2023`, `data2023BPix`.

This keeps the short process names stable across UL and Run-3 while allowing the plotting/grouping machinery to treat them uniformly.


### 8. CR/SR plotting metadata and styles

**File:** `topeft/params/cr_sr_plots_metadata.yml`

- Normalize YAML to explicit lists and scalars (no quoted numbers where unnecessary).
- **CR channel dictionary (`CR_CHAN_DICT`)**
  - Align names with the updated `ch_lst.json`:
    - `cr_2los_Z`, `cr_2los_Z_ee`, `cr_2los_Z_mm`, `cr_2los_tt`, `cr_2lss`, `cr_2lss_flip`, `cr_3l`, flavo-split `3l` groups, and τ CRs:
      - `cr_2los_1tau_Ftau`, `cr_2los_1tau_Ttau`, `cr_1l_1tau`, `cr_1l_1tau_e`, `cr_1l_1tau_m`, `cr_dy_tautau`, `cr_dy_tautau_e`, `cr_dy_tautau_m`.

- **SR channel dictionary (`SR_CHAN_DICT`)**
  - Keep the standard high-level SR groups (`2lss_SR`, `3l_offZ_SR`, `3l_onZ_SR`, `4l_SR`, `2lss_1tau_onZ`, `2lss_1tau_offZ`, `2los_onZ_1tau`).
  - Introduce additional semantic groups:
    - `2lss_1tau`: combined τ SRs (onZ/offZ).
    - `3l_offZ_fwd`: off-Z 3ℓ SRs with forward jet tags.
    - `2lss`: inclusive 2ℓSS (including 4t).
    - `2lss_fwd`: 2ℓSS forward SRs.
    - `3l_1tau`: combined 3ℓ+1τ SRs (1b and 2b).
    - `3l_onZ_fwd`: on-Z 3ℓ forward SRs.
  - These groups line up with the new `ALL_CH_LST_SR` content and are what the audit script and plotting functions operate on.

- **CR/SR group maps (`CR_GRP_MAP`, `SR_GRP_MAP`)**
  - Keep the main physics group names (Data, DY, Ttbar, ZGamma, Diboson, Triboson, Single top, tWZ, Singleboson, Conv, Nonprompt, Flips, Signal).
  - Ensure pattern lists include the extended Run-3 sample names (`TTto`, `TTto2L2Nu`, `TTToSemiLeptonic`, etc., plus 2022EE/2023/BPix variants) via the canonicalization logic in `yield_tools`.

- **Lumi tags**
  - `LUMI_COM_PAIRS` updated to YAML lists and include:
    - `2022EE`, `2023`, `2023BPix` with the correct luminosities and √s.

- **Styling: stacked + ratio plots**
  - Normalize `STACKED_RATIO_STYLE` to plain YAML.
  - Keep the per-region dict open for future overrides (currently empty).
  - Use scientific notation and stable sizing for summary plots.


### 9. Run script: defaults, hist lists, and WQ tuning

**File:** `analysis/topeft_run2/run_analysis.py`

- **CLI defaults**
  - `--chunksize/-s` default: `100000` → `50000`.
  - `--wq-filepath` default: `None` → `/tmp/${USER}-workers`.
  - In `dotest` mode:
    - `chunksize` reduced from `10000` → `100` to emphasise a very fast “smoke test”.

- **Hist list handling**
  - In the default SR hist list (`args.hist_list == ["all"]`):
    - For τ_h analysis:
      - Replace `tau0pt` with `tau0Tpt` and `tau0Fpt`.
    - For CR-only hist list:
      - Likewise, use `tau0Tpt` and `tau0Fpt`.
  - Comment out the heavy L1/seed occupancy 2D histograms (`lepton_pt_vs_eta`, `l*_SeedEtaOrX_vs_SeedPhiOrY`, `l*_eta_vs_phi` and their `*_sumw2` variants) to reduce default output size and runtime overhead.

- **Config file loading**
  - When reading `*.cfg` input files, print the filename alongside the “Reading json from cfg file…” message for easier debugging:
    - `print(" >> Reading json from cfg file...", f)`.

- **Sample bookkeeping**
  - After loading all JSON sample dicts, print:
    - `">> Loaded a total of %i samples from json files." % len(samplesdict)`

- **Work Queue executor tuning**
  - Use slightly stronger compression for chunk outputs:
    - `"compression": 8` → `"compression": 9`.
  - Replace the old `treereduction` parameter with explicit chunk accumulation controls:
    - Drop `"treereduction": 10`.
    - Add:
      - `'chunks_per_accum': 25`,
      - `'chunks_accum_in_mem': 2`.
  - This aims to keep fewer chunks in memory at a time while still coalescing results into moderately sized accumulation tasks.


### 10. Run-3 signal sample cfgs

**Files:**
- `input_samples/cfgs/NDSkim_2022_signal_samples.cfg`
- `input_samples/cfgs/NDSkim_2022EE_signal_samples.cfg`
- `input_samples/cfgs/NDSkim_2023_signal_samples.cfg`
- `input_samples/cfgs/NDSkim_2023BPix_signal_samples.cfg`

- Comment out the older ND_skim JSONs for:
  - `ttHnobb(-1Jets)`, `TTLL_MLL-*`, `TTLNu`, `TTTT`, `TZQB-Zto2L-*`.
- Replace them with the new `samples_jsons` paths for:
  - `tHq`, `tllq`, `ttH`, `ttll`, `ttlnu`, `tttt` for 2022, 2022EE, 2023, 2023BPix.
- This aligns the cfgs with the new Run-3 signal sample naming and JSON layout.


## Backwards-compatibility / migration notes

- **Tau histograms**
  - Any downstream code referring to `tau0pt` must be updated to use:
    - `tau0Tpt` and/or `tau0Fpt` depending on the use-case.

- **CR/SR channel labels**
  - Several labels have been renamed or regrouped (especially for:
    - 1ℓ+1τ CRs,
    - 2ℓ CRs and flips,
    - and the new `ALL_CH_LST_SR` dictionary).
  - Any scripts that hard-code old channel labels (or expect `FWD_CH_LST_SR` only) may need updates.

- **Tau SFs**
  - TES/FES DM coverage changed; fake τ SFs are currently neutralized (set to 1.0).
  - This should be documented in physics notes and revisited when the final Run-3 τ fake SF prescription is available.

- **Group maps**
  - Unmatched samples are no longer grouped into ad-hoc per-process groups; they are skipped and only reported via warnings.
  - If any downstream code relied on those per-process fallback groups, it will need to be adapted to the new behaviour.


## Testing

Recommended / expected tests (to be run before merging):

- Unit tests:
  - [ ] `pytest tests/test_make_cr_and_sr_plots.py`

- CR/SR audit:
  - [ ] Dry-run comparison of processor vs YAML:
    - `python tools/audit_cr_channels_from_processor.py --regions both`
  - [ ] Augmented YAML generation (and manual diff against current metadata):
    - `python tools/audit_cr_channels_from_processor.py --regions SR --write-augmented-yaml --out-meta-yaml topeft/params/cr_sr_plots_metadata.generated.yml`

- Analysis processor:
  - [ ] Local `run_analysis.py` test runs for:
    - Run-2 τ_h analysis (`--tau-h-analysis`, `--year UL18`),
    - Run-3 τ_h analysis (`--tau-h-analysis`, `--year 2022EE` / `2023BPix`),
    - `all_analysis` mode with the new `ALL_CH_LST_SR` channels.
  - [ ] Check that:
    - `tau0Tpt` and `tau0Fpt` histograms are present and filled,
    - zero-yield reports look sensible in both CR and SR regions,
    - and no unexpected warnings from `populate_group_map` remain.

- Work Queue:
  - [ ] Small WQ run using the new defaults:
    - Confirm workers use the new staging directory,
    - Accumulation behaves as expected (no pathological memory usage).


## Checklist

- [ ] Confirm that all relevant downstream configs and notebooks are updated from `tau0pt` to `tau0Tpt`/`tau0Fpt`.
- [ ] Confirm that the updated `SR_CHAN_DICT` and `CR_CHAN_DICT` match the analysis note definitions for Run-3.
- [ ] Decide and document the plan for re-enabling the Run-3 τ fake SFs once a final calibration exists.
- [ ] Re-run central CR/SR plots for a representative subset of samples (UL + Run-3) and compare yields/shapes against previous versions where applicable.
</pre>
