### PR TITLE
Implement ttgamma conversion-overlap sample-role policy

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -25,6 +25,11 @@ from topeft.modules.paths import topeft_path
 from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, AttachTauEnergyCorrections, ApplyTauEnergySystematics, AttachPerLeptonFR, AttachMuonMomentumCorrections, ApplyMuonMomentumSystematics, get_supported_muon_momentum_systematics, get_supported_tau_energy_systematics, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_type1_met
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
+from topeft.modules.ttgamma_photon_history import (
+    attach_conversion_overlap_removal_diagnostics,
+    attach_photon_history_diagnostics,
+    get_ttgamma_sample_role_policy,
+)
 from topcoffea.modules.get_param_from_jsons import GetParam
 get_tc_param = GetParam(topcoffea_path("params/params.json"))
 get_te_param = GetParam(topeft_path("params/params.json"))
@@ -155,7 +160,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         return bool(fill_sumw2_hist) and wgt_fluct == "nominal"
 
-    def __init__(self, samples, wc_names_lst=[], hist_lst=None, ecut_threshold=None, fill_sumw2_hist=True, do_systematics=False, split_by_lepton_flavor=False, skip_signal_regions=False, skip_control_regions=False, muonSyst='nominal', dtype=np.float32, rebin=False, offZ_split=False, tau_h_analysis=False, fwd_analysis=False, all_analysis=False, useRun3MVA=True, tau_run_mode="standard", sr_category_dict=None, cr_category_dict=None, suppress_forward_eta_stochastic_jer=False, fwd_eta_band_pt_apply="auto"):
+    def __init__(self, samples, wc_names_lst=[], hist_lst=None, ecut_threshold=None, fill_sumw2_hist=True, do_systematics=False, split_by_lepton_flavor=False, skip_signal_regions=False, skip_control_regions=False, muonSyst='nominal', dtype=np.float32, rebin=False, offZ_split=False, tau_h_analysis=False, fwd_analysis=False, all_analysis=False, useRun3MVA=True, tau_run_mode="standard", sr_category_dict=None, cr_category_dict=None, suppress_forward_eta_stochastic_jer=False, fwd_eta_band_pt_apply="auto", ttgamma_sample_role_policy="split"):
 
         self._samples = samples
         self._wc_names_lst = wc_names_lst
@@ -207,6 +212,9 @@ class AnalysisProcessor(processor.ProcessorABC):
         self.tau_run_mode = tau_run_mode
         self.suppress_forward_eta_stochastic_jer = suppress_forward_eta_stochastic_jer
         self.fwd_eta_band_pt_apply = fwd_eta_band_pt_apply
+        self._ttgamma_sample_role_policy = get_ttgamma_sample_role_policy(
+            ttgamma_sample_role_policy
+        )
         # self._tau_wp_checked = False
 
         self._fill_sumw2_hist = bool(fill_sumw2_hist)  # Whether to fill the w**2 companion histograms
@@ -819,6 +827,17 @@ class AnalysisProcessor(processor.ProcessorABC):
             l_fo_conept_sorted = l_fo[
                 ak.argsort(l_fo.conept, axis=-1, ascending=False)
             ]
+            l_fo_conept_sorted = attach_photon_history_diagnostics(
+                events,
+                l_fo_conept_sorted,
+                None if isData else events.GenPart,
+            )
+            attach_conversion_overlap_removal_diagnostics(
+                events,
+                sample_name=events.metadata["dataset"],
+                is_data=isData,
+                sample_role_policy=self._ttgamma_sample_role_policy,
+            )
 
             #################### Taus ####################
 
@@ -1810,6 +1829,13 @@ class AnalysisProcessor(processor.ProcessorABC):
                                             all_cuts_mask = (selections.all(*cuts_lst) & njets_any_mask)
                                         else:
                                             all_cuts_mask = selections.all(*cuts_lst)
+                                        all_cuts_mask = (
+                                            all_cuts_mask
+                                            & events[
+                                                "ttgamma_photon_history_"
+                                                "pass_conversion_overlap_removal"
+                                            ]
+                                        )
                                         # Apply the optional cut on energy of the event
                                         if self._ecut_threshold is not None:
                                             all_cuts_mask = (all_cuts_mask & ecut_mask)

--- a/analysis/topeft_run2/fullR3_run.sh
+++ b/analysis/topeft_run2/fullR3_run.sh
@@ -18,6 +18,9 @@ PrintUsage() {
   echo "             Use one sample JSON instead of the default CFG bundle"
   echo "  --cfg-override CFG"
   echo "             Use one CFG file instead of the default CFG bundle"
+  echo "  --ttgamma-sample-role-policy POLICY"
+  echo "             Forward ttgamma sample-role policy to run_analysis.py"
+  echo "             Supported values: split, run2_nlo_inclusive"
   echo "  -p, --outpath PATH"
   echo "             Override the run_analysis.py output directory"
   echo "  --dry-run  Print the resolved run_analysis.py command and exit"
@@ -50,6 +53,7 @@ main() {
   local USER_CHUNK_OVERRIDE=false
   local USER_OUTPATH_OVERRIDE=false
   local USER_OUTPATH_OPTION_COUNT=0
+  local TTGAMMA_SAMPLE_ROLE_POLICY="split"
   local DEFAULT_OUTPATH="/groups/klannon/$USER/"
   local RESOLVED_OUTPATH="$DEFAULT_OUTPATH"
   local TAG=""
@@ -131,6 +135,35 @@ main() {
         fi
         CFG_OVERRIDE="$2"
         shift 2
+        ;;
+      --ttgamma-sample-role-policy)
+        if [[ $# -lt 2 || "$2" == -* ]]; then
+          echo "Error: --ttgamma-sample-role-policy requires a policy value"
+          return 1
+        fi
+        case "$2" in
+          split|run2_nlo_inclusive)
+            TTGAMMA_SAMPLE_ROLE_POLICY="$2"
+            ;;
+          *)
+            echo "Error: unsupported --ttgamma-sample-role-policy value: $2" >&2
+            echo "Supported values: split, run2_nlo_inclusive" >&2
+            return 1
+            ;;
+        esac
+        shift 2
+        ;;
+      --ttgamma-sample-role-policy=*)
+        TTGAMMA_SAMPLE_ROLE_POLICY="${1#--ttgamma-sample-role-policy=}"
+        case "$TTGAMMA_SAMPLE_ROLE_POLICY" in
+          split|run2_nlo_inclusive) ;;
+          *)
+            echo "Error: unsupported --ttgamma-sample-role-policy value: $TTGAMMA_SAMPLE_ROLE_POLICY" >&2
+            echo "Supported values: split, run2_nlo_inclusive" >&2
+            return 1
+            ;;
+        esac
+        shift
         ;;
       -h|--help)
         PrintUsage
@@ -375,6 +408,7 @@ main() {
   echo "Resolved region: $REGION_LABEL"
   echo "Resolved histogram list: ${HIST_LIST_ARGS[*]:1}"
   echo "Resolved output path: $RESOLVED_OUTPATH"
+  echo "Resolved ttgamma sample-role policy: $TTGAMMA_SAMPLE_ROLE_POLICY"
 
   # Define options based on mode
   local -a OPTIONS
@@ -414,6 +448,7 @@ main() {
   local -a RUN_CMD=(python run_analysis.py "$CFGS")
   RUN_CMD+=(--years "${RESOLVED_YEARS[@]}")
   RUN_CMD+=("${OPTIONS[@]}")
+  RUN_CMD+=(--ttgamma-sample-role-policy "$TTGAMMA_SAMPLE_ROLE_POLICY")
   if [[ "$FLAG_DEFER_NP" == "true" ]]; then
     RUN_CMD+=(--np-postprocess=defer)
   fi

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -24,6 +24,11 @@ from topeft.modules.deferred_np_metadata import (
     build_np_followup_command,
 )
 from topeft.modules.get_renormfact_envelope import get_renormfact_envelope
+from topeft.modules.ttgamma_photon_history import (
+    SPLIT_SAMPLE_ROLE_POLICY,
+    SUPPORTED_SAMPLE_ROLE_POLICIES,
+    get_ttgamma_sample_role_policy,
+)
 import analysis_processor
 from analysis.topeft_run2.analysis_processor import (
     ANALYSIS_MODE_EXCLUSIVE_ERROR,
@@ -834,6 +839,16 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
+        "--ttgamma-sample-role-policy",
+        choices=list(SUPPORTED_SAMPLE_ROLE_POLICIES),
+        default=SPLIT_SAMPLE_ROLE_POLICY,
+        help=(
+            "Select the ttgamma conversion-overlap sample-role policy. "
+            "Use 'split' for nominal Run 2 production/decay role splitting, "
+            "or 'run2_nlo_inclusive' for the diagnostic Run 2 TTGJets-inclusive mode."
+        ),
+    )
+    parser.add_argument(
         "--ecut",
         default=None,
         help="Energy cut threshold i.e. throw out events above this (GeV)",
@@ -944,6 +959,7 @@ if __name__ == "__main__":
     wq_filepath = args.wq_filepath
     hist_list = args.hist_list
     category_groups = args.category_groups
+    ttgamma_sample_role_policy = args.ttgamma_sample_role_policy
     analysis_mode = args.analysis_mode
     env_file_override = args.env_file
     use_remote_env = args.use_remote_env
@@ -990,6 +1006,10 @@ if __name__ == "__main__":
         wc_lst = ops.pop("wc_list", wc_lst)
         hist_list = ops.pop("hist_list", hist_list)
         category_groups = ops.pop("category_groups", category_groups)
+        ttgamma_sample_role_policy = ops.pop(
+            "ttgamma_sample_role_policy",
+            ttgamma_sample_role_policy,
+        )
         port = ops.pop("port", port)
         wq_filepath = ops.pop("wq_filepath", wq_filepath)
         ecut = ops.pop("ecut", ecut)
@@ -1012,6 +1032,12 @@ if __name__ == "__main__":
     tau_h_analysis = validated_mode_flags["tau_h_analysis"]
     fwd_analysis = validated_mode_flags["fwd_analysis"]
     all_analysis = validated_mode_flags["all_analysis"]
+    try:
+        ttgamma_sample_role_policy = get_ttgamma_sample_role_policy(
+            ttgamma_sample_role_policy
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
     _ensure_topcoffea_data_available(skip_topcoffea_data_check)
 
     out_pkl_file = os.path.join(outpath, outname + ".pkl.gz")
@@ -1173,6 +1199,11 @@ if __name__ == "__main__":
         hist_lst = hist_list
 
     print("Resolved histogram list: {}".format(", ".join(hist_lst)))
+    print(
+        "Resolved ttgamma sample-role policy: {}".format(
+            ttgamma_sample_role_policy
+        )
+    )
 
     ### Load samples from json
     samplesdict = {}
@@ -1501,6 +1532,7 @@ if __name__ == "__main__":
                 "skip_sr": skip_sr,
                 "skip_cr": skip_cr,
                 "do_systs": do_systs,
+                "ttgamma_sample_role_policy": ttgamma_sample_role_policy,
                 "fwd_eta_band_pt_apply": fwd_eta_band_pt_apply,
                 "fill_sumw2": fill_sumw2,
                 "useRun3MVA": useRun3MVA,
@@ -1592,6 +1624,7 @@ if __name__ == "__main__":
         cr_category_dict=category_group_selection["cr_category_dict"],
         suppress_forward_eta_stochastic_jer=suppress_forward_eta_stochastic_jer,
         fwd_eta_band_pt_apply=fwd_eta_band_pt_apply,
+        ttgamma_sample_role_policy=ttgamma_sample_role_policy,
     )
 
     if executor_name in ["work_queue", "taskvine"]:
@@ -1633,7 +1666,7 @@ if __name__ == "__main__":
             # exploratory mode.
             # 'cores': 1,
             # 'disk': 10000,   #MB
-            # 'memory': 4000, #MB
+            # 'memory': 16000, #MB
             # control the size of accumulation tasks.
             # "treereduction": 10,
             # terminate workers on which tasks have been running longer than average.

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -7,29 +7,66 @@ cd /users/apiccine/work/correction-lib/topeft/analysis/topeft_run2
 # Global configuration
 ###############################################################################
 
-output_dir="/groups/klannon/apiccine/xANv4"
+output_dir="/groups/klannon/apiccine/photons"
 chunk_size="100000"
 
-# Configurable first part of the pkl tag.
-# pkl_base_tag="CR_t1met_fwdpt70_fulleta"
-pkl_base_tag="CR_muonres"
+# Use a branch-specific tag to avoid mixing baseline and feature outputs.
+#
+# Suggested usage:
+#   on run3_test_mmerged_anpicci:
+#     campaign_tag="photon_fbranch_baseline"
+#
+#   on te/ttgamma_conversion_photon_diagnostics:
+#     campaign_tag="photon_fbranch_feature"
+campaign_tag="photon_fbranch_baseline"
 
-# This tag should match what run_analysis.py will actually produce for --hist-list cr.
-# With your current CR block:
-#   hist_lst = ["ptz"]
-#   + "ptz_wtau" when --tau-h-analysis or --all-analysis is enabled.
-vars=(invmass l0ptcorr l0eta) # ptz ptz_wtau)
+cr_pkl_base_tag="CR_${campaign_tag}"
+sr_pkl_base_tag="SR_${campaign_tag}"
+
+# Variables to be produced in both CR and SR pkls.
+vars=(lj0pt ptz)
 var_tag=$(IFS=-; echo "${vars[*]}")
 
-years=(2023 2023BPix 2018)
-# years=(2018) # 2016APV 2016 2017 2018)
+###############################################################################
+# CR configuration
+###############################################################################
+
+# Each entry is one independent year expression passed to fullR3_run.sh.
+# Examples:
+#   cr_year_sets=(2022EE 2018)        # two separate runs
+#   cr_year_sets=("2022EE 2018")      # one combined run
+cr_year_sets=(
+  "2022EE 2018"
+)
 
 # Each entry is one independent subset of categories.
-# The script will run all subsets for every year.
-category_sets=(
+# The script will run all subsets for every year expression.
+cr_category_sets=(
+  "2los_CRtt"
   # "2l_CR 2los_CRtt 3l_CR"
-  "2los_CRZ 2l_CRflip"
+  # "2los_CRZ 2l_CRflip"
   # "2los_1tau 1l_1tau_CRtt 1l_1tau_CRDY"
+)
+
+###############################################################################
+# SR configuration
+###############################################################################
+
+# Each entry is one independent year expression passed to fullR3_run.sh.
+# Examples:
+#   sr_year_sets=(2022 2022EE 2023 2023BPix)              # separate runs
+#   sr_year_sets=("2022 2022EE 2023 2023BPix")            # one combined run
+sr_year_sets=(
+  2022EE
+  2018
+  # "2022 2022EE 2023 2023BPix"
+)
+
+# Each entry is one independent subset of categories.
+# Grouped entries produce one pkl per grouped set.
+sr_category_sets=(
+  "2l 2lss_1tau 2los_1tau 3l_m_offZ"
+  "3l_p_offZ 3l_onZ_tau 3l_fwd 4l"
 )
 
 ###############################################################################
@@ -49,41 +86,47 @@ clean_env_cache() {
   fi
 }
 
-assert_run2_year() {
-  case "$1" in
-    2016APV|2016|2017|2018) ;;
-    *)
-      cat >&2 <<EOF
-ERROR: this CR script is configured for Run 2 only, got year '$1'.
+assert_supported_year_expr() {
+  local year_expr="$1"
+  local year
 
-Before using this script for Run 3:
-  - remove or replace this Run 2 year guard;
-  - change pkl_base_tag from fwdpt40_noband_fulleta to the intended Run 3 tag,
-    e.g. CR_t1met_fwdpt70_fulleta;
-  - remove '--fwd-eta-band-pt-apply off' or replace it with the intended Run 3 policy
-    (default auto already enables the eta-band pT tightening for Run 3);
-  - re-check vars/category_sets for the intended Run 3 production.
+  read -r -a years_in_expr <<< "${year_expr}"
+
+  for year in "${years_in_expr[@]}"; do
+    case "${year}" in
+      2016APV|2016|2017|2018|2022|2022EE|2023|2023BPix) ;;
+      *)
+        cat >&2 <<EOF
+ERROR: unsupported year token '${year}' in year expression '${year_expr}'.
+
+Allowed year tokens:
+  2016APV 2016 2017 2018 2022 2022EE 2023 2023BPix
 EOF
-      exit 1
-      ;;
-  esac
+        exit 1
+        ;;
+    esac
+  done
 }
 
+
 run_cr_block() {
-  local year="$1"
+  local year_expr="$1"
   shift
 
-  # assert_run2_year "${year}"
+  assert_supported_year_expr "${year_expr}"
+
+  local years=()
+  read -r -a years <<< "${year_expr}"
 
   local cats=("$@")
   local cat_tag
   local pkl_tag
 
   cat_tag=$(join_by - "${cats[@]}")
-  pkl_tag="${pkl_base_tag}_${cat_tag}_${var_tag}"
+  pkl_tag="${cr_pkl_base_tag}_${cat_tag}_${var_tag}"
 
   echo "----------------------------------------"
-  echo "Year: ${year}"
+  echo "Years: ${year_expr}"
   echo "Categories: ${cats[*]}"
   echo "Output tag: ${pkl_tag}"
   echo "Output dir: ${output_dir}"
@@ -91,21 +134,21 @@ run_cr_block() {
 
   clean_env_cache
 
-local cmd=(
-  ./fullR3_run.sh
-  -y "${year}"
-  -t "${pkl_tag}"
-  -s "${chunk_size}"
-  --cr
-  --hist-vars "${vars[@]}"
-  --do-systs
-  # --do-np
-  -p "${output_dir}"
-  --category-groups "${cats[@]}"
-  --suppress-forward-eta-stochastic-jer
-  --tau-h-analysis
-  --split-lep-flavor
-)
+  local cmd=(
+    ./fullR3_run.sh
+    -y "${years[@]}"
+    -t "${pkl_tag}"
+    -s "${chunk_size}"
+    --cr
+    --hist-vars "${vars[@]}"
+    # --do-systs
+    --do-np
+    -p "${output_dir}"
+    --category-groups "${cats[@]}"
+    --suppress-forward-eta-stochastic-jer
+    --all-analysis
+    # --split-lep-flavor
+  )
 
   echo "Executing:"
   printf ' %q' "${cmd[@]}"
@@ -113,117 +156,81 @@ local cmd=(
 
   "${cmd[@]}"
 
-  echo "${year} done"
+  echo "${year_expr} done"
   echo "----------------------------------------"
   echo
 }
 
+run_sr_block() {
+  local year_expr="$1"
+  shift
+
+  assert_supported_year_expr "${year_expr}"
+
+  local years=()
+  read -r -a years <<< "${year_expr}"
+
+  local cats=("$@")
+  local cat_tag
+  local pkl_tag
+
+  cat_tag=$(join_by - "${cats[@]}")
+  pkl_tag="${sr_pkl_base_tag}_${cat_tag}_${var_tag}"
+
+  echo "----------------------------------------"
+  echo "Years: ${year_expr}"
+  echo "Categories: ${cats[*]}"
+  echo "Output tag: ${pkl_tag}"
+  echo "Output dir: ${output_dir}"
+  echo "----------------------------------------"
+
+  clean_env_cache
+
+  local cmd=(
+    ./fullR3_run.sh
+    -y "${years[@]}"
+    -t "${pkl_tag}"
+    -s "${chunk_size}"
+    --sr
+    --hist-vars "${vars[@]}"
+    # --do-systs
+    --do-np
+    -p "${output_dir}"
+    --category-groups "${cats[@]}"
+    --suppress-forward-eta-stochastic-jer
+    --all-analysis
+    # --split-lep-flavor
+  )
+
+  echo "Executing:"
+  printf ' %q' "${cmd[@]}"
+  echo
+
+  "${cmd[@]}"
+
+  echo "${year_expr} done"
+  echo "----------------------------------------"
+  echo
+}
+
+# ###############################################################################
+# # Main CR production
+# ###############################################################################
+
+# for year_expr in "${cr_year_sets[@]}"; do
+#   for category_set in "${cr_category_sets[@]}"; do
+#     read -r -a cats <<< "${category_set}"
+#     run_cr_block "${year_expr}" "${cats[@]}"
+#   done
+# done
+
 ###############################################################################
-# Main CR production
+# Main SR production
 ###############################################################################
 
-for year in "${years[@]}"; do
-  for category_set in "${category_sets[@]}"; do
+for year_expr in "${sr_year_sets[@]}"; do
+  for category_set in "${sr_category_sets[@]}"; do
     read -r -a cats <<< "${category_set}"
-    run_cr_block "${year}" "${cats[@]}"
+    run_sr_block "${year_expr}" "${cats[@]}"
   done
 done
-
-###############################################################################
-# Parking area for future CR runs
-###############################################################################
-
-# If you later change the run_analysis.py CR hist list, update vars accordingly.
-#
-# Example if you restore lj0pt/met/fwd0eta:
-#
-# vars=(lj0pt met fwd0eta ptz ptz_wtau)
-# var_tag=$(IFS=-; echo "${vars[*]}")
-
-# Non-tau CR groups, first block:
-#
-# vars=(fwd0eta)
-# var_tag=$(IFS=-; echo "${vars[*]}")
-# category_sets=(
-#   "2l_CR 2l_CRflip 3l_CR"
-# )
-#
-# for year in "${years[@]}"; do
-#   for category_set in "${category_sets[@]}"; do
-#     read -r -a cats <<< "${category_set}"
-#     run_cr_block "${year}" "${cats[@]}"
-#   done
-# done
-
-# Non-tau CR groups, second block:
-#
-# vars=(fwd0eta)
-# var_tag=$(IFS=-; echo "${vars[*]}")
-# category_sets=(
-#   "2los_CRZ 2los_CRtt"
-# )
-#
-# for year in "${years[@]}"; do
-#   for category_set in "${category_sets[@]}"; do
-#     read -r -a cats <<< "${category_set}"
-#     run_cr_block "${year}" "${cats[@]}"
-#   done
-# done
-
-###############################################################################
-# Parking area for future SR runs
-###############################################################################
-
-# run_sr_block() {
-#   local year_expr="$1"
-#   shift
-#
-#   local cats=("$@")
-#   local cat_tag
-#   local pkl_tag
-#
-#   cat_tag=$(join_by - "${cats[@]}")
-#   pkl_tag="SR_fwdfix_pt70ext_${cat_tag}"
-#
-#   echo "----------------------------------------"
-#   echo "Years: ${year_expr}"
-#   echo "SR categories: ${cats[*]}"
-#   echo "Output tag: ${pkl_tag}"
-#   echo "Output dir: ${output_dir}"
-#   echo "----------------------------------------"
-#
-#   clean_env_cache
-#
-#   local cmd=(
-#     ./fullR3_run.sh
-#     -y "${year_expr}"
-#     -t "${pkl_tag}"
-#     -s "${chunk_size}"
-#     --sr
-#     --do-systs
-#     --do-np
-#     -p "${output_dir}"
-#     --category-groups "${cats[@]}"
-#     --suppress-forward-eta-stochastic-jer
-#     --all-analysis
-#   )
-#
-#   echo "Executing:"
-#   printf ' %q' "${cmd[@]}"
-#   echo
-#
-#   "${cmd[@]}"
-#
-#   echo "Done"
-#   echo "----------------------------------------"
-#   echo
-# }
-#
-# run_sr_block "2022 2022EE 2023 2023BPix" 2l
-# run_sr_block "2022 2022EE 2023 2023BPix" 2lss_1tau
-# run_sr_block "2022 2022EE 2023 2023BPix" 2los_1tau
-# run_sr_block "2022 2022EE 2023 2023BPix" 3l_m_offZ
-# run_sr_block "2022 2022EE 2023 2023BPix" 3l_p_offZ
-# run_sr_block "2022 2022EE 2023 2023BPix" 3l_onZ_tau
-# run_sr_block "2022 2022EE 2023 2023BPix" 3l_fwd
-# run_sr_block "2022 2022EE 2023 2023BPix" 4l

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -7,29 +7,80 @@ cd /users/apiccine/work/correction-lib/topeft/analysis/topeft_run2
 # Global configuration
 ###############################################################################
 
-output_dir="/groups/klannon/apiccine/xANv4"
+output_dir="/groups/klannon/apiccine/photons"
 chunk_size="100000"
 
-# Configurable first part of the pkl tag.
-# pkl_base_tag="CR_t1met_fwdpt70_fulleta"
-pkl_base_tag="CR_muonres"
+# Nominal TOP-23-002-like ttgamma sample-role strategy.
+#
+# Run 2:
+#   TTGJets NLO                         -> production-like ttgamma
+#   TTGamma_Dilept / TTGamma_SingleLept -> decay-like ttgamma
+#   inclusive ttbar                     -> veto selected external-conversion-like leptons
+#
+# Run 3:
+#   TTG-1Jets_PTG-*                     -> inclusive ttgamma treatment
+#   inclusive ttbar                     -> veto selected external-conversion-like leptons
+#
+# The diagnostic Run 2 NLO-only policy is intentionally not used here.
+ttgamma_sample_role_policy="split"
 
-# This tag should match what run_analysis.py will actually produce for --hist-list cr.
-# With your current CR block:
-#   hist_lst = ["ptz"]
-#   + "ptz_wtau" when --tau-h-analysis or --all-analysis is enabled.
-vars=(invmass l0ptcorr l0eta) # ptz ptz_wtau)
+# Use a strategy-specific tag to avoid mixing baseline/feature/diagnostic outputs.
+campaign_tag="rolepolicy_v2"
+
+cr_pkl_base_tag="CR_${campaign_tag}"
+sr_pkl_base_tag="SR_${campaign_tag}"
+
+# Variables to be produced in both CR and SR pkls.
+vars=(lj0pt ptz)
 var_tag=$(IFS=-; echo "${vars[*]}")
 
-years=(2023 2023BPix 2018)
-# years=(2018) # 2016APV 2016 2017 2018)
+# Execution switches.
+#
+# Current default preserves the recent usage: produce SR pkls only.
+# Set run_cr=true when you want CR production as well.
+run_cr=false
+run_sr=true
+
+###############################################################################
+# CR configuration
+###############################################################################
+
+# Each entry is one independent year expression passed to fullR3_run.sh.
+# Examples:
+#   cr_year_sets=(2022EE 2018)        # two separate runs
+#   cr_year_sets=("2022EE 2018")      # one combined run
+cr_year_sets=(
+  "2022EE 2018"
+)
 
 # Each entry is one independent subset of categories.
-# The script will run all subsets for every year.
-category_sets=(
+# The script will run all subsets for every year expression.
+cr_category_sets=(
+  "2los_CRtt"
   # "2l_CR 2los_CRtt 3l_CR"
-  "2los_CRZ 2l_CRflip"
+  # "2los_CRZ 2l_CRflip"
   # "2los_1tau 1l_1tau_CRtt 1l_1tau_CRDY"
+)
+
+###############################################################################
+# SR configuration
+###############################################################################
+
+# Each entry is one independent year expression passed to fullR3_run.sh.
+# Examples:
+#   sr_year_sets=(2022 2022EE 2023 2023BPix)              # separate runs
+#   sr_year_sets=("2022 2022EE 2023 2023BPix")            # one combined run
+sr_year_sets=(
+  2022EE
+  2018
+  # "2022 2022EE 2023 2023BPix"
+)
+
+# Each entry is one independent subset of categories.
+# Grouped entries produce one pkl per grouped set.
+sr_category_sets=(
+  "2l 2lss_1tau 2los_1tau 3l_m_offZ"
+  "3l_p_offZ 3l_onZ_tau 3l_fwd 4l"
 )
 
 ###############################################################################
@@ -39,6 +90,7 @@ category_sets=(
 join_by() {
   local delimiter="$1"
   shift
+
   local IFS="$delimiter"
   echo "$*"
 }
@@ -49,181 +101,208 @@ clean_env_cache() {
   fi
 }
 
-assert_run2_year() {
-  case "$1" in
-    2016APV|2016|2017|2018) ;;
-    *)
-      cat >&2 <<EOF
-ERROR: this CR script is configured for Run 2 only, got year '$1'.
+assert_supported_year_expr() {
+  local year_expr="$1"
+  local year
+  local years_in_expr=()
 
-Before using this script for Run 3:
-  - remove or replace this Run 2 year guard;
-  - change pkl_base_tag from fwdpt40_noband_fulleta to the intended Run 3 tag,
-    e.g. CR_t1met_fwdpt70_fulleta;
-  - remove '--fwd-eta-band-pt-apply off' or replace it with the intended Run 3 policy
-    (default auto already enables the eta-band pT tightening for Run 3);
-  - re-check vars/category_sets for the intended Run 3 production.
+  read -r -a years_in_expr <<< "${year_expr}"
+
+  for year in "${years_in_expr[@]}"; do
+    case "${year}" in
+      2016APV|2016|2017|2018|2022|2022EE|2023|2023BPix) ;;
+      *)
+        cat >&2 <<EOF
+ERROR: unsupported year token '${year}' in year expression '${year_expr}'.
+
+Allowed year tokens:
+  2016APV 2016 2017 2018 2022 2022EE 2023 2023BPix
 EOF
-      exit 1
-      ;;
-  esac
+        exit 1
+        ;;
+    esac
+  done
+}
+
+print_command() {
+  local -a cmd=("$@")
+
+  echo "Executing:"
+  printf ' %q' "${cmd[@]}"
+  echo
 }
 
 run_cr_block() {
-  local year="$1"
+  local year_expr="$1"
   shift
 
-  # assert_run2_year "${year}"
+  assert_supported_year_expr "${year_expr}"
+
+  local years=()
+  read -r -a years <<< "${year_expr}"
 
   local cats=("$@")
   local cat_tag
   local pkl_tag
 
   cat_tag=$(join_by - "${cats[@]}")
-  pkl_tag="${pkl_base_tag}_${cat_tag}_${var_tag}"
+  pkl_tag="${cr_pkl_base_tag}_${cat_tag}_${var_tag}"
 
   echo "----------------------------------------"
-  echo "Year: ${year}"
+  echo "Mode: CR"
+  echo "Years: ${year_expr}"
   echo "Categories: ${cats[*]}"
+  echo "ttgamma sample-role policy: ${ttgamma_sample_role_policy}"
+  echo "Campaign tag: ${campaign_tag}"
   echo "Output tag: ${pkl_tag}"
   echo "Output dir: ${output_dir}"
   echo "----------------------------------------"
 
   clean_env_cache
 
-local cmd=(
-  ./fullR3_run.sh
-  -y "${year}"
-  -t "${pkl_tag}"
-  -s "${chunk_size}"
-  --cr
-  --hist-vars "${vars[@]}"
-  --do-systs
-  # --do-np
-  -p "${output_dir}"
-  --category-groups "${cats[@]}"
-  --suppress-forward-eta-stochastic-jer
-  --tau-h-analysis
-  --split-lep-flavor
-)
+  local cmd=(
+    ./fullR3_run.sh
+    -y "${years[@]}"
+    -t "${pkl_tag}"
+    -s "${chunk_size}"
+    --cr
+    --hist-vars "${vars[@]}"
+    --ttgamma-sample-role-policy "${ttgamma_sample_role_policy}"
+    # --do-systs
+    --do-np
+    -p "${output_dir}"
+    --category-groups "${cats[@]}"
+    --suppress-forward-eta-stochastic-jer
+    --all-analysis
+    # --split-lep-flavor
+  )
 
-  echo "Executing:"
-  printf ' %q' "${cmd[@]}"
-  echo
-
+  print_command "${cmd[@]}"
   "${cmd[@]}"
 
-  echo "${year} done"
+  echo "${year_expr} CR done"
+  echo "----------------------------------------"
+  echo
+}
+
+run_sr_block() {
+  local year_expr="$1"
+  shift
+
+  assert_supported_year_expr "${year_expr}"
+
+  local years=()
+  read -r -a years <<< "${year_expr}"
+
+  local cats=("$@")
+  local cat_tag
+  local pkl_tag
+
+  cat_tag=$(join_by - "${cats[@]}")
+  pkl_tag="${sr_pkl_base_tag}_${cat_tag}_${var_tag}"
+
+  echo "----------------------------------------"
+  echo "Mode: SR"
+  echo "Years: ${year_expr}"
+  echo "Categories: ${cats[*]}"
+  echo "ttgamma sample-role policy: ${ttgamma_sample_role_policy}"
+  echo "Campaign tag: ${campaign_tag}"
+  echo "Output tag: ${pkl_tag}"
+  echo "Output dir: ${output_dir}"
+  echo "----------------------------------------"
+
+  clean_env_cache
+
+  local cmd=(
+    ./fullR3_run.sh
+    -y "${years[@]}"
+    -t "${pkl_tag}"
+    -s "${chunk_size}"
+    --sr
+    --hist-vars "${vars[@]}"
+    --ttgamma-sample-role-policy "${ttgamma_sample_role_policy}"
+    # --do-systs
+    --do-np
+    -p "${output_dir}"
+    --category-groups "${cats[@]}"
+    --suppress-forward-eta-stochastic-jer
+    --all-analysis
+    # --split-lep-flavor
+  )
+
+  print_command "${cmd[@]}"
+  "${cmd[@]}"
+
+  echo "${year_expr} SR done"
   echo "----------------------------------------"
   echo
 }
 
 ###############################################################################
+# Preflight summary
+###############################################################################
+
+echo "========================================"
+echo "run_cr.sh configuration"
+echo "campaign_tag: ${campaign_tag}"
+echo "ttgamma sample-role policy: ${ttgamma_sample_role_policy}"
+echo "output_dir: ${output_dir}"
+echo "chunk_size: ${chunk_size}"
+echo "vars: ${vars[*]}"
+echo "run_cr: ${run_cr}"
+echo "run_sr: ${run_sr}"
+echo "========================================"
+echo
+
+case "${ttgamma_sample_role_policy}" in
+  split) ;;
+  *)
+    cat >&2 <<EOF
+ERROR: this production helper is intended to run the nominal split policy.
+
+Current ttgamma_sample_role_policy:
+  ${ttgamma_sample_role_policy}
+
+Expected:
+  split
+EOF
+    exit 1
+    ;;
+esac
+
+###############################################################################
 # Main CR production
 ###############################################################################
 
-for year in "${years[@]}"; do
-  for category_set in "${category_sets[@]}"; do
-    read -r -a cats <<< "${category_set}"
-    run_cr_block "${year}" "${cats[@]}"
+if [[ "${run_cr}" == "true" ]]; then
+  for year_expr in "${cr_year_sets[@]}"; do
+    for category_set in "${cr_category_sets[@]}"; do
+      read -r -a cats <<< "${category_set}"
+      run_cr_block "${year_expr}" "${cats[@]}"
+    done
   done
-done
+else
+  echo "Skipping CR production because run_cr=${run_cr}"
+  echo
+fi
 
 ###############################################################################
-# Parking area for future CR runs
+# Main SR production
 ###############################################################################
 
-# If you later change the run_analysis.py CR hist list, update vars accordingly.
-#
-# Example if you restore lj0pt/met/fwd0eta:
-#
-# vars=(lj0pt met fwd0eta ptz ptz_wtau)
-# var_tag=$(IFS=-; echo "${vars[*]}")
+if [[ "${run_sr}" == "true" ]]; then
+  for year_expr in "${sr_year_sets[@]}"; do
+    for category_set in "${sr_category_sets[@]}"; do
+      read -r -a cats <<< "${category_set}"
+      run_sr_block "${year_expr}" "${cats[@]}"
+    done
+  done
+else
+  echo "Skipping SR production because run_sr=${run_sr}"
+  echo
+fi
 
-# Non-tau CR groups, first block:
-#
-# vars=(fwd0eta)
-# var_tag=$(IFS=-; echo "${vars[*]}")
-# category_sets=(
-#   "2l_CR 2l_CRflip 3l_CR"
-# )
-#
-# for year in "${years[@]}"; do
-#   for category_set in "${category_sets[@]}"; do
-#     read -r -a cats <<< "${category_set}"
-#     run_cr_block "${year}" "${cats[@]}"
-#   done
-# done
-
-# Non-tau CR groups, second block:
-#
-# vars=(fwd0eta)
-# var_tag=$(IFS=-; echo "${vars[*]}")
-# category_sets=(
-#   "2los_CRZ 2los_CRtt"
-# )
-#
-# for year in "${years[@]}"; do
-#   for category_set in "${category_sets[@]}"; do
-#     read -r -a cats <<< "${category_set}"
-#     run_cr_block "${year}" "${cats[@]}"
-#   done
-# done
-
-###############################################################################
-# Parking area for future SR runs
-###############################################################################
-
-# run_sr_block() {
-#   local year_expr="$1"
-#   shift
-#
-#   local cats=("$@")
-#   local cat_tag
-#   local pkl_tag
-#
-#   cat_tag=$(join_by - "${cats[@]}")
-#   pkl_tag="SR_fwdfix_pt70ext_${cat_tag}"
-#
-#   echo "----------------------------------------"
-#   echo "Years: ${year_expr}"
-#   echo "SR categories: ${cats[*]}"
-#   echo "Output tag: ${pkl_tag}"
-#   echo "Output dir: ${output_dir}"
-#   echo "----------------------------------------"
-#
-#   clean_env_cache
-#
-#   local cmd=(
-#     ./fullR3_run.sh
-#     -y "${year_expr}"
-#     -t "${pkl_tag}"
-#     -s "${chunk_size}"
-#     --sr
-#     --do-systs
-#     --do-np
-#     -p "${output_dir}"
-#     --category-groups "${cats[@]}"
-#     --suppress-forward-eta-stochastic-jer
-#     --all-analysis
-#   )
-#
-#   echo "Executing:"
-#   printf ' %q' "${cmd[@]}"
-#   echo
-#
-#   "${cmd[@]}"
-#
-#   echo "Done"
-#   echo "----------------------------------------"
-#   echo
-# }
-#
-# run_sr_block "2022 2022EE 2023 2023BPix" 2l
-# run_sr_block "2022 2022EE 2023 2023BPix" 2lss_1tau
-# run_sr_block "2022 2022EE 2023 2023BPix" 2los_1tau
-# run_sr_block "2022 2022EE 2023 2023BPix" 3l_m_offZ
-# run_sr_block "2022 2022EE 2023 2023BPix" 3l_p_offZ
-# run_sr_block "2022 2022EE 2023 2023BPix" 3l_onZ_tau
-# run_sr_block "2022 2022EE 2023 2023BPix" 3l_fwd
-# run_sr_block "2022 2022EE 2023 2023BPix" 4l
+echo "run_cr.sh completed"
+echo "campaign_tag: ${campaign_tag}"
+echo "ttgamma sample-role policy: ${ttgamma_sample_role_policy}"
+echo "output_dir: ${output_dir}"

--- a/analysis/topeft_run2/run_ttgamma.sh
+++ b/analysis/topeft_run2/run_ttgamma.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /users/apiccine/work/correction-lib/topeft/analysis/topeft_run2
+
+###############################################################################
+# CL007AT reduced-sample role-policy-v2 production
+###############################################################################
+
+dryRun=false
+policyMode="split"
+
+PrintUsage() {
+  cat <<EOF
+Usage: $0 [--dry-run] [--ttgamma-sample-role-policy POLICY]
+
+Options:
+  --dry-run
+      Print resolved reduced-cfg contents and fullR3_run.sh commands only.
+  --ttgamma-sample-role-policy POLICY
+      Supported values: split, run2_nlo_inclusive.
+      Default: split.
+
+The run2_nlo_inclusive policy is diagnostic-only and must be requested
+explicitly.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      dryRun=true
+      shift
+      ;;
+    --ttgamma-sample-role-policy)
+      if [[ $# -lt 2 || "$2" == -* ]]; then
+        echo "ERROR: --ttgamma-sample-role-policy requires a policy value" >&2
+        exit 2
+      fi
+      policyMode="$2"
+      shift 2
+      ;;
+    --ttgamma-sample-role-policy=*)
+      policyMode="${1#--ttgamma-sample-role-policy=}"
+      shift
+      ;;
+    -h|--help)
+      PrintUsage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unsupported argument: $1" >&2
+      PrintUsage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "${policyMode}" in
+  split|run2_nlo_inclusive) ;;
+  *)
+    cat >&2 <<EOF
+ERROR: policyMode must be one of:
+  split
+  run2_nlo_inclusive
+EOF
+    exit 2
+    ;;
+esac
+
+###############################################################################
+# Global configuration
+###############################################################################
+
+outputDir="/groups/klannon/apiccine/photons"
+chunkSize="100000"
+
+case "${policyMode}" in
+  split)
+    campaignTag="rolepolicy_v2"
+    ttgammaSampleRolePolicy="split"
+    ;;
+  run2_nlo_inclusive)
+    campaignTag="rolepolicy_v2_run2NloInclusive"
+    ttgammaSampleRolePolicy="run2_nlo_inclusive"
+    ;;
+esac
+srPklBaseTag="SR_${campaignTag}"
+
+# Variables to be produced in the SR pkls.
+histVars=(lj0pt ptz)
+varTag=$(IFS=-; echo "${histVars[*]}")
+
+# Run 3 comparison year. Use 2022EE to match the previous validation.
+# Change to 2022 only if you intentionally want the pre-EE era.
+run3Year="${CL007AT_RUN3_YEAR:-2022EE}"
+if [[ "${policyMode}" == "split" ]]; then
+  case "${run3Year}" in
+    2022|2022EE) ;;
+    *)
+      echo "ERROR: CL007AT_RUN3_YEAR must be 2022 or 2022EE." >&2
+      exit 2
+      ;;
+  esac
+fi
+
+###############################################################################
+# SR configuration
+###############################################################################
+
+if [[ "${policyMode}" == "split" ]]; then
+  # Each entry is one independent year expression passed to fullR3_run.sh.
+  # Keep these separate because each year uses a different reduced cfg override.
+  srYearSets=(
+    "${run3Year}"
+    2018
+  )
+else
+  srYearSets=(
+    2018
+  )
+fi
+
+# Each entry is one independent subset of categories.
+# Grouped entries produce one pkl per grouped set.
+srCategorySets=(
+  "2l 2lss_1tau 2los_1tau 3l_m_offZ"
+  "3l_p_offZ 3l_onZ_tau 3l_fwd 4l"
+)
+
+###############################################################################
+# Reduced cfg configuration
+###############################################################################
+
+repoRoot="/users/apiccine/work/correction-lib/topeft"
+run2JsonRoot="${repoRoot}/input_samples/sample_jsons/background_samples/central_UL"
+run3JsonRoot="${repoRoot}/input_samples/sample_jsons/background_samples/ND_SRskim${run3Year}"
+
+cfgDir="/tmp/cl007at_${campaignTag}_$(date -u +%Y%m%dT%H%M%SZ)_$$"
+mkdir -p "${cfgDir}"
+
+###############################################################################
+# Helpers
+###############################################################################
+
+JoinBy() {
+  local delimiter="$1"
+  shift
+  local IFS="${delimiter}"
+  echo "$*"
+}
+
+CleanEnvCache() {
+  if [[ -d topeft-envs ]]; then
+    find topeft-envs -mindepth 1 -maxdepth 1 \( -type f -o -type l \) -delete
+  fi
+}
+
+AssertSupportedYearExpr() {
+  local yearExpr="$1"
+  local year
+
+  read -r -a yearsInExpr <<< "${yearExpr}"
+
+  for year in "${yearsInExpr[@]}"; do
+    case "${year}" in
+      2018|2022|2022EE) ;;
+      *)
+        cat >&2 <<EOF
+ERROR: unsupported year token '${year}' in year expression '${yearExpr}'.
+
+Allowed year tokens for this reduced ttgamma helper:
+  2018 2022 2022EE
+EOF
+        exit 1
+        ;;
+    esac
+  done
+}
+
+AssertJsonsExist() {
+  local jsonPath
+  for jsonPath in "$@"; do
+    if [[ ! -f "${jsonPath}" ]]; then
+      echo "ERROR: audited sample JSON is missing: ${jsonPath}" >&2
+      exit 1
+    fi
+  done
+}
+
+WriteReducedCfg() {
+  local year="$1"
+  local cfgPath="$2"
+  local -a jsons=()
+
+  case "${year}" in
+    2018)
+      if [[ "${policyMode}" == "run2_nlo_inclusive" ]]; then
+        jsons=(
+          "${run2JsonRoot}/UL18_TTGJets_NDSkim.json"
+          "${run2JsonRoot}/UL18_TTTo2L2Nu_NDSkim.json"
+          "${run2JsonRoot}/UL18_TTToSemiLeptonic_NDSkim.json"
+        )
+      else
+        jsons=(
+          "${run2JsonRoot}/UL18_TTGJets_NDSkim.json"
+          "${run2JsonRoot}/UL18_TTGamma_Dilept_NDSkim.json"
+          "${run2JsonRoot}/UL18_TTGamma_SingleLept_NDSkim.json"
+          "${run2JsonRoot}/UL18_TTTo2L2Nu_NDSkim.json"
+          "${run2JsonRoot}/UL18_TTToSemiLeptonic_NDSkim.json"
+        )
+      fi
+      ;;
+    2022|2022EE)
+      jsons=(
+        "${run3JsonRoot}/TTG-1Jets_PTG-10to100_NDSkim_${year}.json"
+        "${run3JsonRoot}/TTG-1Jets_PTG-100to200_NDSkim_${year}.json"
+        "${run3JsonRoot}/TTG-1Jets_PTG-200_NDSkim_${year}.json"
+        "${run3JsonRoot}/TTto2L2Nu_NDSkim_${year}.json"
+        "${run3JsonRoot}/TTtoLNu2Q_NDSkim_${year}.json"
+      )
+      ;;
+    *)
+      echo "ERROR: unsupported year for reduced cfg: ${year}" >&2
+      exit 2
+      ;;
+  esac
+
+  AssertJsonsExist "${jsons[@]}"
+
+  {
+    echo "root://cmsxrootd.crc.nd.edu/"
+    printf '%s\n' "${jsons[@]}"
+  } > "${cfgPath}"
+}
+
+RunSrBlock() {
+  local yearExpr="$1"
+  local cfgPath="$2"
+  shift 2
+
+  AssertSupportedYearExpr "${yearExpr}"
+
+  local years=()
+  read -r -a years <<< "${yearExpr}"
+
+  local cats=("$@")
+  local catTag
+  local pklTag
+  local expectedPkl
+  local expectedNpPkl
+  local cmd=()
+
+  catTag=$(JoinBy - "${cats[@]}")
+  pklTag="${srPklBaseTag}_${catTag}_${varTag}"
+
+  expectedPkl="${outputDir}/${yearExpr}SRs_${pklTag}.pkl.gz"
+  expectedNpPkl="${outputDir}/${yearExpr}SRs_${pklTag}_np.pkl.gz"
+
+  if [[ -e "${expectedPkl}" || -e "${expectedNpPkl}" ]]; then
+    if [[ "${dryRun}" == "true" ]]; then
+      echo "WARNING: existing pkl path would block a real run for tag ${pklTag}" >&2
+      echo "Expected base pkl: ${expectedPkl}" >&2
+      echo "Expected NP pkl:   ${expectedNpPkl}" >&2
+    else
+      echo "ERROR: refusing to overwrite an existing pkl for tag ${pklTag}" >&2
+      echo "Expected base pkl: ${expectedPkl}" >&2
+      echo "Expected NP pkl:   ${expectedNpPkl}" >&2
+      exit 1
+    fi
+  fi
+
+  echo "----------------------------------------"
+  echo "Policy mode: ${policyMode}"
+  echo "Campaign/tag: ${campaignTag}"
+  echo "ttgamma sample-role policy: ${ttgammaSampleRolePolicy}"
+  echo "Years: ${yearExpr}"
+  echo "Categories: ${cats[*]}"
+  echo "Cfg override: ${cfgPath}"
+  if [[ "${dryRun}" == "true" ]]; then
+    echo "Reduced cfg contents:"
+    sed 's/^/  /' "${cfgPath}"
+  fi
+  echo "Output tag: ${pklTag}"
+  echo "Output dir: ${outputDir}"
+  echo "Expected base pkl: ${expectedPkl}"
+  echo "Expected NP pkl:   ${expectedNpPkl}"
+  echo "Dry run: ${dryRun}"
+  echo "----------------------------------------"
+
+  CleanEnvCache
+
+  cmd=(
+    ./fullR3_run.sh
+    -y "${years[@]}"
+    -t "${pklTag}"
+    -s "${chunkSize}"
+    --sr
+    --cfg-override "${cfgPath}"
+    --ttgamma-sample-role-policy "${ttgammaSampleRolePolicy}"
+    --hist-vars "${histVars[@]}"
+    --do-np
+    -p "${outputDir}"
+    --category-groups "${cats[@]}"
+    --suppress-forward-eta-stochastic-jer
+    --all-analysis
+  )
+
+  if [[ "${dryRun}" == "true" ]]; then
+    cmd+=(--dry-run --pretend --nchunks 1)
+  fi
+
+  echo "Executing:"
+  printf ' %q' "${cmd[@]}"
+  echo
+
+  "${cmd[@]}"
+
+  echo "${yearExpr} done"
+  echo "----------------------------------------"
+  echo
+}
+
+###############################################################################
+# Main SR production
+###############################################################################
+
+for yearExpr in "${srYearSets[@]}"; do
+  cfgPath="${cfgDir}/ttgamma_ttbar_${yearExpr}.cfg"
+  WriteReducedCfg "${yearExpr}" "${cfgPath}"
+
+  for categorySet in "${srCategorySets[@]}"; do
+    read -r -a cats <<< "${categorySet}"
+    RunSrBlock "${yearExpr}" "${cfgPath}" "${cats[@]}"
+  done
+done
+
+echo "run_ttgamma.sh completed"
+echo "Policy mode: ${policyMode}"
+echo "Campaign/tag: ${campaignTag}"
+echo "ttgamma sample-role policy: ${ttgammaSampleRolePolicy}"
+echo "Cfg directory: ${cfgDir}"
+echo "Output directory: ${outputDir}"
+
+if [[ "${dryRun}" == "true" ]]; then
+  echo "No pkls were produced because --dry-run was requested."
+fi

--- a/input_samples/cfgs/mc_background_samples_NDSkim.cfg
+++ b/input_samples/cfgs/mc_background_samples_NDSkim.cfg
@@ -6,6 +6,8 @@ root://cmsxrootd.crc.nd.edu/
 ../../input_samples/sample_jsons/background_samples/central_UL/UL16APV_TWZToLL_thad_Wlept_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL16APV_TWZToLL_tlept_Whad_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL16APV_TWZToLL_tlept_Wlept_NDSkim.json
+# Run 2 ttgamma is split by sample role: NLO TTGJets for production-like photons, LO TTGamma for decay-like photons; overlap removal enforces the role split.
+../../input_samples/sample_jsons/background_samples/central_UL/UL16APV_TTGJets_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL16APV_TTGamma_Dilept_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL16APV_TTGamma_SingleLept_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL16APV_WWTo2L2Nu_NDSkim.json
@@ -33,6 +35,8 @@ root://cmsxrootd.crc.nd.edu/
 ../../input_samples/sample_jsons/background_samples/central_UL/UL16_TWZToLL_thad_Wlept_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL16_TWZToLL_tlept_Whad_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL16_TWZToLL_tlept_Wlept_NDSkim.json
+# Run 2 ttgamma is split by sample role: NLO TTGJets for production-like photons, LO TTGamma for decay-like photons; overlap removal enforces the role split.
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_TTGJets_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL16_TTGamma_Dilept_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL16_TTGamma_SingleLept_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL16_WWTo2L2Nu_NDSkim.json
@@ -60,6 +64,8 @@ root://cmsxrootd.crc.nd.edu/
 ../../input_samples/sample_jsons/background_samples/central_UL/UL17_TWZToLL_thad_Wlept_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL17_TWZToLL_tlept_Whad_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL17_TWZToLL_tlept_Wlept_NDSkim.json
+# Run 2 ttgamma is split by sample role: NLO TTGJets for production-like photons, LO TTGamma for decay-like photons; overlap removal enforces the role split.
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_TTGJets_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL17_TTGamma_Dilept_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL17_TTGamma_SingleLept_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL17_WWTo2L2Nu_NDSkim.json
@@ -87,6 +93,8 @@ root://cmsxrootd.crc.nd.edu/
 ../../input_samples/sample_jsons/background_samples/central_UL/UL18_TWZToLL_thad_Wlept_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL18_TWZToLL_tlept_Whad_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL18_TWZToLL_tlept_Wlept_NDSkim.json
+# Run 2 ttgamma is split by sample role: NLO TTGJets for production-like photons, LO TTGamma for decay-like photons; overlap removal enforces the role split.
+../../input_samples/sample_jsons/background_samples/central_UL/UL18_TTGJets_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL18_TTGamma_Dilept_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL18_TTGamma_SingleLept_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL18_WWTo2L2Nu_NDSkim.json

--- a/tests/test_ttgamma_photon_history.py
+++ b/tests/test_ttgamma_photon_history.py
@@ -1,0 +1,1000 @@
+from pathlib import Path
+
+import awkward as ak
+import pytest
+
+from topeft.modules.ttgamma_photon_history import (
+    AMBIGUOUS,
+    DECAY_LEPTON,
+    DECAY_TOP_COPY_CONDITION,
+    DECAY_W_OR_B_WITH_TOP_ANCESTOR,
+    HADRON_ANCESTOR,
+    INVALID_MATCH,
+    NO_PHOTON_FOUND,
+    NOT_CONVERSION,
+    PRODUCTION_ISR,
+    PRODUCTION_OFFSHELL_TOP,
+    attach_conversion_overlap_removal_diagnostics,
+    attach_photon_history_diagnostics,
+    classify_conversion_overlap_sample,
+    classify_selected_conversion_photon_history,
+)
+from topeft.modules.yield_tools import YieldTools
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _genpart(pdg_id, mother=-1):
+    return {"pdgId": pdg_id, "genPartIdxMother": mother}
+
+
+def _lepton(gen_part_idx, gen_part_flav=22):
+    return {"genPartIdx": gen_part_idx, "genPartFlav": gen_part_flav}
+
+
+def _classify(genparts, leptons, max_depth=64):
+    return classify_selected_conversion_photon_history(
+        ak.Array(genparts),
+        ak.Array(leptons),
+        max_depth=max_depth,
+    )
+
+
+def _categories(result):
+    return ak.to_list(result["lepton"]["category"])
+
+
+def _event(result, field):
+    return ak.to_list(result["event"][field])
+
+
+def _overlap_events(decay, production, has_selected=None, **guard_fields):
+    if has_selected is None:
+        has_selected = [
+            has_decay or has_production
+            for has_decay, has_production in zip(decay, production)
+        ]
+    events = {
+        "ttgamma_photon_history_has_selected_conversion_lepton": ak.Array(
+            has_selected
+        ),
+        "ttgamma_photon_history_has_decay_origin_conversion_photon": ak.Array(
+            decay
+        ),
+        "ttgamma_photon_history_has_production_origin_conversion_photon": (
+            ak.Array(production)
+        ),
+    }
+    for field, values in guard_fields.items():
+        events[f"ttgamma_photon_history_{field}"] = ak.Array(values)
+    return events
+
+
+def _attach_overlap(
+    sample_name,
+    decay,
+    production,
+    has_selected=None,
+    is_data=False,
+    sample_role_policy="split",
+    **guards,
+):
+    events = _overlap_events(
+        decay,
+        production,
+        has_selected=has_selected,
+        **guards,
+    )
+    result = attach_conversion_overlap_removal_diagnostics(
+        events,
+        sample_name=sample_name,
+        is_data=is_data,
+        sample_role_policy=sample_role_policy,
+    )
+    return events, {
+        field: ak.to_list(values) for field, values in result.items()
+    }
+
+
+@pytest.mark.parametrize(
+    ("sample_name", "expected"),
+    [
+        ("TTGJets_centralUL18", "ttgamma_production"),
+        ("UL18_TTGJets_NDSkim", "ttgamma_production"),
+        ("TTGamma_centralUL18", "ttgamma_decay"),
+        ("UL18_TTGamma_Dilept_NDSkim", "ttgamma_decay"),
+        ("TTG-1Jets_PTG-10to100_NDSkim_2022EE", "ttgamma_inclusive"),
+        ("TTto2L2Nu_central2022EE", "inclusive_ttbar"),
+    ],
+)
+def test_default_sample_role_policy_is_split(sample_name, expected):
+    assert classify_conversion_overlap_sample(sample_name) == expected
+
+
+def test_explicit_split_sample_role_policy_keeps_run2_ttgamma_nlo_split():
+    assert (
+        classify_conversion_overlap_sample(
+            "TTGJets_centralUL18",
+            sample_role_policy="split",
+        )
+        == "ttgamma_production"
+    )
+    assert (
+        classify_conversion_overlap_sample(
+            "UL18_TTGJets_NDSkim",
+            sample_role_policy="split",
+        )
+        == "ttgamma_production"
+    )
+
+
+@pytest.mark.parametrize(
+    ("sample_name", "expected"),
+    [
+        ("TTGJets_centralUL18", "ttgamma_inclusive"),
+        ("UL18_TTGJets_NDSkim", "ttgamma_inclusive"),
+        ("TTGamma_centralUL18", "ttgamma_decay"),
+        ("TTG-1Jets_PTG-10to100_NDSkim_2022EE", "ttgamma_inclusive"),
+        ("TTTo2L2Nu_centralUL18", "inclusive_ttbar"),
+    ],
+)
+def test_run2_nlo_inclusive_policy_classification(sample_name, expected):
+    assert (
+        classify_conversion_overlap_sample(
+            sample_name,
+            sample_role_policy="run2_nlo_inclusive",
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("sample_name", "expected"),
+    [
+        ("TTGamma_centralUL18", "ttgamma_decay"),
+        ("UL18_TTGamma_Dilept_NDSkim", "ttgamma_decay"),
+        (
+            "TTG-1Jets_PTG-10to100_NDSkim_2022",
+            "ttgamma_inclusive",
+        ),
+        ("TTTo2L2Nu_centralUL18", "inclusive_ttbar"),
+    ],
+)
+def test_run2_nlo_inclusive_policy_preserves_other_roles(
+    sample_name,
+    expected,
+):
+    assert (
+        classify_conversion_overlap_sample(
+            sample_name,
+            sample_role_policy="run2_nlo_inclusive",
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("decay", "production"),
+    [([True], [False]), ([False], [True])],
+)
+def test_run2_nlo_inclusive_policy_keeps_run2_ttgamma_nlo_origins(
+    decay,
+    production,
+):
+    _, result = _attach_overlap(
+        "UL18_TTGJets_NDSkim",
+        decay,
+        production,
+        sample_role_policy="run2_nlo_inclusive",
+    )
+
+    assert result["sample_role_is_ttgamma_inclusive"] == [True]
+    assert result["removed_by_conversion_overlap_removal"] == [False]
+    assert result["pass_conversion_overlap_removal"] == [True]
+
+
+def test_run2_nlo_inclusive_policy_keeps_inclusive_ttbar_selected_veto():
+    _, result = _attach_overlap(
+        "UL18_TTTo2L2Nu_NDSkim",
+        [False],
+        [False],
+        has_selected=[True],
+        sample_role_policy="run2_nlo_inclusive",
+    )
+
+    assert result["sample_role_is_inclusive_ttbar"] == [True]
+    assert result["removed_ttbar_selected_external_conversion"] == [True]
+    assert result["removed_by_conversion_overlap_removal"] == [True]
+    assert result["pass_conversion_overlap_removal"] == [False]
+
+
+def test_invalid_sample_role_policy_raises():
+    with pytest.raises(ValueError, match="unsupported_policy"):
+        classify_conversion_overlap_sample(
+            "UL18_TTGJets_NDSkim",
+            sample_role_policy="unsupported_policy",
+        )
+
+
+@pytest.mark.parametrize(
+    ("sample_name", "expected"),
+    [
+        ("UL16APV_TTGJets_NDSkim", "ttgamma_production"),
+        ("UL16_TTGJets_NDSkim", "ttgamma_production"),
+        ("UL17_TTGJets_NDSkim", "ttgamma_production"),
+        ("UL18_TTGJets_NDSkim", "ttgamma_production"),
+        ("TTGJets_centralUL18", "ttgamma_production"),
+        ("UL16APV_TTGamma_Dilept_NDSkim", "ttgamma_decay"),
+        ("UL16APV_TTGamma_SingleLept_NDSkim", "ttgamma_decay"),
+        ("UL16_TTGamma_Dilept_NDSkim", "ttgamma_decay"),
+        ("UL16_TTGamma_SingleLept_NDSkim", "ttgamma_decay"),
+        ("UL17_TTGamma_Dilept_NDSkim", "ttgamma_decay"),
+        ("UL17_TTGamma_SingleLept_NDSkim", "ttgamma_decay"),
+        ("UL18_TTGamma_Dilept_NDSkim", "ttgamma_decay"),
+        ("UL18_TTGamma_SingleLept_NDSkim", "ttgamma_decay"),
+        ("TTGamma_centralUL18", "ttgamma_decay"),
+        (
+            "TTG-1Jets_PTG-10to100_NDSkim_2022",
+            "ttgamma_inclusive",
+        ),
+        (
+            "TTG-1Jets_PTG-100to200_NDSkim_2022",
+            "ttgamma_inclusive",
+        ),
+        (
+            "TTG-1Jets_PTG-200_NDSkim_2022",
+            "ttgamma_inclusive",
+        ),
+        (
+            "TTG-1Jets_PTG-10to100_NDSkim_2022EE",
+            "ttgamma_inclusive",
+        ),
+        (
+            "TTG-1Jets_PTG-100to200_NDSkim_2022EE",
+            "ttgamma_inclusive",
+        ),
+        (
+            "TTG-1Jets_PTG-200_NDSkim_2022EE",
+            "ttgamma_inclusive",
+        ),
+        (
+            "TTG-1Jets_PTG-10to100_NDSkim_2023",
+            "ttgamma_inclusive",
+        ),
+        (
+            "TTG-1Jets_PTG-100to200_NDSkim_2023",
+            "ttgamma_inclusive",
+        ),
+        (
+            "TTG-1Jets_PTG-200_NDSkim_2023",
+            "ttgamma_inclusive",
+        ),
+        (
+            "TTG-1Jets_PTG-10to100_NDSkim_2023BPix",
+            "ttgamma_inclusive",
+        ),
+        (
+            "TTG-1Jets_PTG-100to200_NDSkim_2023BPix",
+            "ttgamma_inclusive",
+        ),
+        (
+            "TTG-1Jets_PTG-200_NDSkim_2023BPix",
+            "ttgamma_inclusive",
+        ),
+        (
+            "TTG-1Jets_PTG-100to200_central2022",
+            "ttgamma_inclusive",
+        ),
+        ("TTGamma_central2022EE", "ttgamma_inclusive"),
+        ("UL16APV_TTTo2L2Nu_NDSkim", "inclusive_ttbar"),
+        ("UL16APV_TTToSemiLeptonic_NDSkim", "inclusive_ttbar"),
+        ("UL16_TTTo2L2Nu_NDSkim", "inclusive_ttbar"),
+        ("UL16_TTToSemiLeptonic_NDSkim", "inclusive_ttbar"),
+        ("UL17_TTTo2L2Nu_NDSkim", "inclusive_ttbar"),
+        ("UL17_TTToSemiLeptonic_NDSkim", "inclusive_ttbar"),
+        ("UL18_TTTo2L2Nu_NDSkim", "inclusive_ttbar"),
+        ("UL18_TTToSemiLeptonic_NDSkim", "inclusive_ttbar"),
+        ("UL18_TTToHadronic", "inclusive_ttbar"),
+        ("UL18_TTJets", "inclusive_ttbar"),
+        ("TTto2L2Nu-2Jets_2022", "inclusive_ttbar"),
+        ("TTto2L2Nu_NDSkim_2022", "inclusive_ttbar"),
+        ("TTtoLNu2Q_NDSkim_2022", "inclusive_ttbar"),
+        ("TTto2L2Nu_NDSkim_2022EE", "inclusive_ttbar"),
+        ("TTtoLNu2Q_NDSkim_2022EE", "inclusive_ttbar"),
+        ("TTto2L2Nu_NDSkim_2023", "inclusive_ttbar"),
+        ("TTtoLNu2Q_NDSkim_2023", "inclusive_ttbar"),
+        ("TTto2L2Nu_NDSkim_2023BPix", "inclusive_ttbar"),
+        ("TTtoLNu2Q_NDSkim_2023BPix", "inclusive_ttbar"),
+        ("TTto4Q_2023BPix", "inclusive_ttbar"),
+        ("TTto2L2Nu_central2022EE", "inclusive_ttbar"),
+        ("input/Muon_2022.json", "other"),
+    ],
+)
+def test_conversion_overlap_sample_classifier_supported_names(
+    sample_name, expected
+):
+    assert classify_conversion_overlap_sample(sample_name) == expected
+
+
+@pytest.mark.parametrize(
+    "sample_name",
+    [
+        "TTWJetsToLNu",
+        "TTZToLLNuNu_M_10",
+        "ttHnobb",
+        "ST_top_t-channel_2022",
+        "ST_tW_Leptonic_2023",
+        "ZZTo4l_TTJets",
+        "Muon_2022",
+        "TTGamma_unknown",
+        "TTG-1Jets_PTG-10to100_2018",
+    ],
+)
+def test_conversion_overlap_sample_classifier_is_conservative(sample_name):
+    assert classify_conversion_overlap_sample(sample_name) == "other"
+
+
+@pytest.mark.parametrize(
+    "year",
+    ["2022", "2022EE", "2023", "2023BPix"],
+)
+@pytest.mark.parametrize(
+    "pt_bin",
+    ["10to100", "100to200", "200"],
+)
+def test_run3_ttgamma_hist_axes_are_in_conversion_group(year, pt_bin):
+    process = f"TTG-1Jets_PTG-{pt_bin}_central{year}"
+    assert YieldTools().get_short_name(process) == "conv"
+
+
+@pytest.mark.parametrize(
+    "sample_name",
+    [
+        "UL16APV_TTGJets_NDSkim",
+        "UL16_TTGJets_NDSkim",
+        "UL17_TTGJets_NDSkim",
+        "UL18_TTGJets_NDSkim",
+    ],
+)
+def test_ttgamma_production_role_removes_decay_origin_only(sample_name):
+    _, result = _attach_overlap(sample_name, [True], [False])
+
+    assert result[
+        "removed_ttgamma_production_role_decay_origin"
+    ] == [True]
+    assert result[
+        "removed_ttgamma_decay_role_production_origin"
+    ] == [False]
+    assert result["removed_ttbar_selected_external_conversion"] == [False]
+    assert result["removed_by_conversion_overlap_removal"] == [True]
+    assert result["pass_conversion_overlap_removal"] == [False]
+
+
+def test_ttgamma_production_role_keeps_production_origin():
+    _, result = _attach_overlap("UL18_TTGJets_NDSkim", [False], [True])
+
+    assert result["removed_by_conversion_overlap_removal"] == [False]
+    assert result["pass_conversion_overlap_removal"] == [True]
+
+
+@pytest.mark.parametrize(
+    "sample_name",
+    [
+        "UL16APV_TTGamma_Dilept_NDSkim",
+        "UL16_TTGamma_SingleLept_NDSkim",
+        "UL17_TTGamma_Dilept_NDSkim",
+        "UL18_TTGamma_SingleLept_NDSkim",
+    ],
+)
+def test_ttgamma_decay_role_removes_production_origin_only(sample_name):
+    _, result = _attach_overlap(sample_name, [False], [True])
+
+    assert result[
+        "removed_ttgamma_production_role_decay_origin"
+    ] == [False]
+    assert result[
+        "removed_ttgamma_decay_role_production_origin"
+    ] == [True]
+    assert result["removed_ttbar_selected_external_conversion"] == [False]
+    assert result["removed_by_conversion_overlap_removal"] == [True]
+    assert result["pass_conversion_overlap_removal"] == [False]
+
+
+def test_ttgamma_decay_role_keeps_decay_origin():
+    _, result = _attach_overlap(
+        "UL18_TTGamma_Dilept_NDSkim",
+        [True],
+        [False],
+    )
+
+    assert result["removed_by_conversion_overlap_removal"] == [False]
+    assert result["pass_conversion_overlap_removal"] == [True]
+
+
+@pytest.mark.parametrize(
+    "sample_name",
+    [
+        "TTG-1Jets_PTG-10to100_NDSkim_2022",
+        "TTG-1Jets_PTG-100to200_NDSkim_2022EE",
+        "TTG-1Jets_PTG-200_NDSkim_2023",
+        "TTG-1Jets_PTG-10to100_NDSkim_2023BPix",
+    ],
+)
+@pytest.mark.parametrize(
+    ("decay", "production"),
+    [([True], [False]), ([False], [True]), ([True], [True])],
+)
+def test_ttgamma_inclusive_keeps_all_classified_origins(
+    sample_name,
+    decay,
+    production,
+):
+    _, result = _attach_overlap(sample_name, decay, production)
+
+    assert result["removed_by_conversion_overlap_removal"] == [False]
+    assert result["pass_conversion_overlap_removal"] == [True]
+
+
+@pytest.mark.parametrize(
+    "sample_name",
+    [
+        "UL18_TTTo2L2Nu",
+        "UL18_TTToSemiLeptonic",
+        "UL18_TTToHadronic",
+        "UL18_TTJets",
+        "TTto2L2Nu_2022",
+        "TTtoLNu2Q_2023",
+        "TTto4Q_2023BPix",
+    ],
+)
+def test_inclusive_ttbar_removes_selected_external_conversion(sample_name):
+    _, result = _attach_overlap(
+        sample_name,
+        [False],
+        [False],
+        has_selected=[True],
+    )
+
+    assert result["removed_ttbar_selected_external_conversion"] == [True]
+    assert result["removed_by_conversion_overlap_removal"] == [True]
+    assert result["pass_conversion_overlap_removal"] == [False]
+
+
+def test_inclusive_ttbar_without_selected_conversion_passes():
+    _, result = _attach_overlap(
+        "UL18_TTTo2L2Nu",
+        [True],
+        [True],
+        has_selected=[False],
+    )
+
+    assert result["removed_by_conversion_overlap_removal"] == [False]
+    assert result["pass_conversion_overlap_removal"] == [True]
+
+
+@pytest.mark.parametrize(
+    "sample_name",
+    ["UL18_TTGJets", "UL18_TTGamma_Dilept"],
+)
+def test_ttgamma_guard_categories_do_not_drive_role_veto(sample_name):
+    _, result = _attach_overlap(
+        sample_name,
+        [False],
+        [False],
+        has_recovered_conversion_photon=[True],
+        has_classified_origin_conversion_photon=[False],
+        has_hadron_ancestor_conversion_photon=[True],
+        has_ambiguous_conversion_photon=[True],
+        has_no_photon_found_conversion_lepton=[True],
+        has_invalid_match_conversion_lepton=[True],
+    )
+
+    assert result["removed_by_conversion_overlap_removal"] == [False]
+    assert result["pass_conversion_overlap_removal"] == [True]
+
+
+def test_inclusive_ttbar_veto_does_not_require_recovered_photon_ancestry():
+    _, result = _attach_overlap(
+        "UL18_TTTo2L2Nu",
+        [False],
+        [False],
+        has_selected=[True],
+        has_recovered_conversion_photon=[False],
+        has_classified_origin_conversion_photon=[False],
+        has_no_photon_found_conversion_lepton=[True],
+        has_invalid_match_conversion_lepton=[True],
+    )
+
+    assert result["removed_ttbar_selected_external_conversion"] == [True]
+    assert result["pass_conversion_overlap_removal"] == [False]
+
+
+@pytest.mark.parametrize(
+    ("sample_name", "is_data", "expected_pass"),
+    [
+        ("WJetsToLNu_2022", False, True),
+        ("UL18_TTGamma_Dilept", True, True),
+        ("UL18_TTTo2L2Nu", True, True),
+    ],
+)
+def test_other_mc_and_data_pass_unchanged(
+    sample_name, is_data, expected_pass
+):
+    _, result = _attach_overlap(
+        sample_name,
+        [True],
+        [True],
+        is_data=is_data,
+    )
+
+    assert result[
+        "removed_ttgamma_production_role_decay_origin"
+    ] == [False]
+    assert result[
+        "removed_ttgamma_decay_role_production_origin"
+    ] == [False]
+    assert result["removed_ttbar_selected_external_conversion"] == [False]
+    assert result["pass_conversion_overlap_removal"] == [expected_pass]
+
+
+@pytest.mark.parametrize(
+    ("sample_name", "expected_role_field", "expected_removed"),
+    [
+        (
+            "UL18_TTGJets",
+            "sample_role_is_ttgamma_production",
+            True,
+        ),
+        (
+            "UL18_TTGamma_Dilept",
+            "sample_role_is_ttgamma_decay",
+            True,
+        ),
+        (
+            "TTG-1Jets_PTG-10to100_2022",
+            "sample_role_is_ttgamma_inclusive",
+            False,
+        ),
+        (
+            "UL18_TTTo2L2Nu",
+            "sample_role_is_inclusive_ttbar",
+            True,
+        ),
+    ],
+)
+def test_mixed_origin_truth_table_and_role_diagnostics(
+    sample_name,
+    expected_role_field,
+    expected_removed,
+):
+    events, result = _attach_overlap(sample_name, [True], [True])
+
+    assert result[
+        "has_mixed_decay_and_production_conversion_photons"
+    ] == [True]
+    assert result["removed_by_conversion_overlap_removal"] == [
+        expected_removed
+    ]
+    assert result["pass_conversion_overlap_removal"] == [
+        not expected_removed
+    ]
+    assert result[expected_role_field] == [True]
+    assert (
+        "ttgamma_photon_history_"
+        "has_mixed_decay_and_production_conversion_photons"
+    ) in events
+
+
+def test_non_conversion_lepton_is_not_a_candidate():
+    result = _classify(
+        [[_genpart(22)]],
+        [[_lepton(0, gen_part_flav=1)]],
+    )
+
+    assert _categories(result) == [[NOT_CONVERSION]]
+    assert _event(result, "has_selected_conversion_lepton") == [False]
+    assert _event(result, "n_recovered_conversion_photons") == [0]
+    assert _event(result, "n_classified_origin_conversion_photons") == [0]
+
+
+def test_direct_photon_match_and_decay_lepton_classification():
+    result = _classify(
+        [[_genpart(11), _genpart(22, 0)]],
+        [[_lepton(1)]],
+    )
+
+    assert _categories(result) == [[DECAY_LEPTON]]
+    assert ak.to_list(result["lepton"]["recovered_photon_index"]) == [[1]]
+    assert ak.to_list(result["lepton"]["first_copy_photon_index"]) == [[1]]
+    assert _event(result, "has_recovered_conversion_photon") == [True]
+    assert _event(result, "has_classified_origin_conversion_photon") == [True]
+    assert _event(result, "has_decay_origin_conversion_photon") == [True]
+
+
+def test_recovers_photon_from_immediate_mother():
+    result = _classify(
+        [[_genpart(1), _genpart(22, 0), _genpart(11, 1)]],
+        [[_lepton(2)]],
+    )
+
+    assert _categories(result) == [[PRODUCTION_ISR]]
+    assert ak.to_list(result["lepton"]["recovered_photon_index"]) == [[1]]
+
+
+def test_recovers_photon_from_bounded_ancestor_chain():
+    result = _classify(
+        [[
+            _genpart(1),
+            _genpart(22, 0),
+            _genpart(11, 1),
+            _genpart(11, 2),
+        ]],
+        [[_lepton(3)]],
+    )
+
+    assert _categories(result) == [[PRODUCTION_ISR]]
+    assert ak.to_list(result["lepton"]["recovered_photon_index"]) == [[1]]
+
+
+def test_invalid_initial_match_and_no_photon_found_are_distinct():
+    result = _classify(
+        [[_genpart(11, -1)]],
+        [[_lepton(9), _lepton(0)]],
+    )
+
+    assert _categories(result) == [[INVALID_MATCH, NO_PHOTON_FOUND]]
+    assert _event(result, "has_recovered_conversion_photon") == [False]
+    assert _event(result, "has_classified_origin_conversion_photon") == [False]
+    assert _event(result, "has_invalid_match_conversion_lepton") == [True]
+    assert _event(result, "has_no_photon_found_conversion_lepton") == [True]
+
+
+def test_first_copy_normalization_walks_same_pdg_photon_mothers():
+    result = _classify(
+        [[_genpart(1), _genpart(22, 0), _genpart(22, 1)]],
+        [[_lepton(2)]],
+    )
+
+    assert _categories(result) == [[PRODUCTION_ISR]]
+    assert ak.to_list(result["lepton"]["recovered_photon_index"]) == [[2]]
+    assert ak.to_list(result["lepton"]["first_copy_photon_index"]) == [[1]]
+
+
+def test_decay_w_or_b_requires_a_top_ancestor():
+    result = _classify(
+        [[_genpart(6), _genpart(24, 0), _genpart(22, 1)]],
+        [[_lepton(2)]],
+    )
+
+    assert _categories(result) == [[DECAY_W_OR_B_WITH_TOP_ANCESTOR]]
+
+
+def test_decay_top_copy_condition_uses_signed_top_copy():
+    result = _classify(
+        [[_genpart(-6), _genpart(-6, 0), _genpart(22, 1)]],
+        [[_lepton(2)]],
+    )
+
+    assert _categories(result) == [[DECAY_TOP_COPY_CONDITION]]
+
+
+def test_production_isr_and_offshell_top_categories():
+    result = _classify(
+        [[
+            _genpart(1),
+            _genpart(22, 0),
+            _genpart(21),
+            _genpart(6, 2),
+            _genpart(22, 3),
+        ]],
+        [[_lepton(1), _lepton(4)]],
+    )
+
+    assert _categories(result) == [[PRODUCTION_ISR, PRODUCTION_OFFSHELL_TOP]]
+    assert _event(result, "n_production_origin_conversion_photons") == [2]
+
+
+def test_gluon_mother_is_offshell_top_production_category():
+    result = _classify(
+        [[_genpart(21), _genpart(22, 0)]],
+        [[_lepton(1)]],
+    )
+
+    assert _categories(result) == [[PRODUCTION_OFFSHELL_TOP]]
+
+
+def test_hadron_ancestor_has_precedence_over_origin_category():
+    result = _classify(
+        [[_genpart(111), _genpart(22, 0)]],
+        [[_lepton(1)]],
+    )
+
+    assert _categories(result) == [[HADRON_ANCESTOR]]
+    assert _event(result, "has_recovered_conversion_photon") == [True]
+    assert _event(result, "has_classified_origin_conversion_photon") == [False]
+    assert _event(result, "has_hadron_ancestor_conversion_photon") == [True]
+    assert _event(result, "has_decay_origin_conversion_photon") == [False]
+    assert _event(result, "has_production_origin_conversion_photon") == [False]
+
+
+def test_no_mother_and_malformed_cycle_are_ambiguous():
+    result = _classify(
+        [
+            [_genpart(22, -1)],
+            [_genpart(22, 1), _genpart(22, 0)],
+        ],
+        [
+            [_lepton(0)],
+            [_lepton(0)],
+        ],
+        max_depth=4,
+    )
+
+    assert _categories(result) == [[AMBIGUOUS], [AMBIGUOUS]]
+    assert _event(result, "has_recovered_conversion_photon") == [True, True]
+    assert _event(result, "has_classified_origin_conversion_photon") == [
+        False,
+        False,
+    ]
+    assert _event(result, "has_ambiguous_conversion_photon") == [True, True]
+
+
+def test_multiple_conversion_leptons_reduce_to_event_counts():
+    result = _classify(
+        [[
+            _genpart(11),
+            _genpart(22, 0),
+            _genpart(1),
+            _genpart(22, 2),
+        ]],
+        [[_lepton(1), _lepton(3), _lepton(0, gen_part_flav=1)]],
+    )
+
+    assert _categories(result) == [
+        [DECAY_LEPTON, PRODUCTION_ISR, NOT_CONVERSION]
+    ]
+    assert _event(result, "n_selected_conversion_leptons") == [2]
+    assert _event(result, "n_recovered_conversion_photons") == [2]
+    assert _event(result, "n_classified_origin_conversion_photons") == [2]
+    assert _event(result, "n_decay_origin_conversion_photons") == [1]
+    assert _event(result, "n_production_origin_conversion_photons") == [1]
+
+
+def test_recovered_and_classified_origin_partitions_include_guard_categories():
+    result = _classify(
+        [[
+            _genpart(11),
+            _genpart(22, 0),
+            _genpart(1),
+            _genpart(22, 2),
+            _genpart(111),
+            _genpart(22, 4),
+            _genpart(22),
+            _genpart(11),
+        ]],
+        [[
+            _lepton(1),
+            _lepton(3),
+            _lepton(5),
+            _lepton(6),
+            _lepton(7),
+            _lepton(99),
+            _lepton(1, gen_part_flav=1),
+        ]],
+    )
+
+    assert _categories(result) == [[
+        DECAY_LEPTON,
+        PRODUCTION_ISR,
+        HADRON_ANCESTOR,
+        AMBIGUOUS,
+        NO_PHOTON_FOUND,
+        INVALID_MATCH,
+        NOT_CONVERSION,
+    ]]
+    assert ak.to_list(
+        result["lepton"]["has_recovered_conversion_photon"]
+    ) == [[True, True, True, True, False, False, False]]
+
+    event = result["event"]
+    assert ak.to_list(event["n_recovered_conversion_photons"]) == [4]
+    assert ak.to_list(event["n_classified_origin_conversion_photons"]) == [2]
+    assert ak.to_list(event["n_decay_origin_conversion_photons"]) == [1]
+    assert ak.to_list(event["n_production_origin_conversion_photons"]) == [1]
+    assert ak.to_list(event["n_hadron_ancestor_conversion_photons"]) == [1]
+    assert ak.to_list(event["n_ambiguous_conversion_photons"]) == [1]
+    assert ak.to_list(event["n_no_photon_found_conversion_leptons"]) == [1]
+    assert ak.to_list(event["n_invalid_match_conversion_leptons"]) == [1]
+
+    assert ak.to_list(event["n_recovered_conversion_photons"]) == ak.to_list(
+        event["n_classified_origin_conversion_photons"]
+        + event["n_hadron_ancestor_conversion_photons"]
+        + event["n_ambiguous_conversion_photons"]
+    )
+    assert ak.to_list(
+        event["n_classified_origin_conversion_photons"]
+    ) == ak.to_list(
+        event["n_decay_origin_conversion_photons"]
+        + event["n_production_origin_conversion_photons"]
+    )
+    assert ak.to_list(
+        event["has_classified_origin_conversion_photon"]
+    ) == ak.to_list(
+        event["has_decay_origin_conversion_photon"]
+        | event["has_production_origin_conversion_photon"]
+    )
+
+
+def test_empty_event_is_supported():
+    result = _classify(
+        [[], [_genpart(1), _genpart(22, 0)]],
+        [[], [_lepton(1)]],
+    )
+
+    assert _categories(result) == [[], [PRODUCTION_ISR]]
+    assert _event(result, "n_selected_conversion_leptons") == [0, 1]
+
+
+def test_missing_gen_or_lepton_branches_returns_false_diagnostics():
+    leptons = ak.Array([[{"pt": 25.0}], []])
+    result = classify_selected_conversion_photon_history(None, leptons)
+
+    assert _categories(result) == [[NOT_CONVERSION], []]
+    assert _event(result, "diagnostic_missing_branches") == [True, True]
+    assert _event(result, "has_selected_conversion_lepton") == [False, False]
+    assert _event(result, "n_selected_conversion_leptons") == [0, 0]
+
+
+def test_attachment_path_handles_data_like_missing_gen_fields():
+    events = {}
+    leptons = ak.Array([[{"pt": 25.0}], []])
+
+    attached = attach_photon_history_diagnostics(
+        events,
+        leptons,
+        genparts=None,
+    )
+
+    assert isinstance(attached, ak.Array)
+    assert not isinstance(attached, tuple)
+    assert "conversion_photon_history_category" in ak.fields(attached)
+    assert (
+        "conversion_photon_history_recovered_photon_index"
+        in ak.fields(attached)
+    )
+    assert (
+        "conversion_photon_history_has_recovered_conversion_photon"
+        in ak.fields(attached)
+    )
+    stale_index_field = (
+        "conversion_photon_history_" + "matched_" + "photon_index"
+    )
+    assert stale_index_field not in ak.fields(attached)
+    stale_lepton_flag = (
+        "conversion_photon_history_" + "has_" + "matched_conversion_photon"
+    )
+    assert (
+        stale_lepton_flag not in ak.fields(attached)
+    )
+    assert ak.to_list(
+        events["ttgamma_photon_history_diagnostic_missing_branches"]
+    ) == [True, True]
+    assert (
+        "ttgamma_photon_history_has_classified_origin_conversion_photon"
+        in events
+    )
+    assert "ttgamma_photon_history_has_decay_origin_conversion_photon" in events
+    assert (
+        "ttgamma_photon_history_has_production_origin_conversion_photon"
+        in events
+    )
+    stale_event_flag = (
+        "ttgamma_photon_history_" + "has_" + "matched_conversion_photon"
+    )
+    stale_event_count = (
+        "ttgamma_photon_history_" + "n_" + "matched_conversion_photons"
+    )
+    assert stale_event_flag not in events
+    assert stale_event_count not in events
+    assert ak.to_list(
+        events["ttgamma_photon_history_has_selected_conversion_lepton"]
+    ) == [False, False]
+
+
+def test_processor_attaches_and_consumes_overlap_removal_diagnostics():
+    processor_source = (
+        REPO_ROOT / "analysis" / "topeft_run2" / "analysis_processor.py"
+    ).read_text()
+    selection_source = (
+        REPO_ROOT / "topeft" / "modules" / "event_selection.py"
+    ).read_text()
+
+    attach_position = processor_source.index(
+        "attach_photon_history_diagnostics("
+    )
+    overlap_position = processor_source.index(
+        "attach_conversion_overlap_removal_diagnostics(", attach_position
+    )
+    event_selection_position = processor_source.index(
+        "te_es.add1lMaskAndSFs(", overlap_position
+    )
+    final_mask_position = processor_source.index(
+        '"pass_conversion_overlap_removal"', event_selection_position
+    )
+
+    assert attach_position < overlap_position < event_selection_position
+    assert event_selection_position < final_mask_position
+    assert "ttgamma_sample_role_policy=\"split\"" in processor_source
+    assert "self._ttgamma_sample_role_policy = get_ttgamma_sample_role_policy" in (
+        processor_source
+    )
+    assert "sample_role_policy=self._ttgamma_sample_role_policy" in (
+        processor_source
+    )
+    assert "all_cuts_mask" in processor_source[
+        final_mask_position - 250 : final_mask_position + 250
+    ]
+    assert "ttgamma_photon_history_" not in selection_source
+    assert "conversion_photon_history_" not in selection_source
+
+
+def test_ttgamma_sample_role_policy_defaults_are_split_source_guards():
+    module_source = (
+        REPO_ROOT / "topeft" / "modules" / "ttgamma_photon_history.py"
+    ).read_text()
+    processor_source = (
+        REPO_ROOT / "analysis" / "topeft_run2" / "analysis_processor.py"
+    ).read_text()
+    run_analysis_source = (
+        REPO_ROOT / "analysis" / "topeft_run2" / "run_analysis.py"
+    ).read_text()
+    full_r3_source = (
+        REPO_ROOT / "analysis" / "topeft_run2" / "fullR3_run.sh"
+    ).read_text()
+    run_ttgamma_source = (
+        REPO_ROOT / "analysis" / "topeft_run2" / "run_ttgamma.sh"
+    ).read_text()
+
+    assert 'SPLIT_SAMPLE_ROLE_POLICY = "split"' in module_source
+    assert (
+        "RUN2_NLO_INCLUSIVE_SAMPLE_ROLE_POLICY = "
+        '"run2_nlo_inclusive"'
+    ) in module_source
+    assert "sample_role_policy=SPLIT_SAMPLE_ROLE_POLICY" in module_source
+    assert "os.environ" not in module_source
+    assert "TOPEFT_TTGAMMA_SAMPLE_ROLE_POLICY" not in module_source
+    assert "CL007AT_POLICY_MODE" not in module_source
+
+    assert 'ttgamma_sample_role_policy="split"' in processor_source
+    assert "default=SPLIT_SAMPLE_ROLE_POLICY" in run_analysis_source
+    assert 'local TTGAMMA_SAMPLE_ROLE_POLICY="split"' in full_r3_source
+    assert (
+        'RUN_CMD+=(--ttgamma-sample-role-policy '
+        '"$TTGAMMA_SAMPLE_ROLE_POLICY")'
+    ) in full_r3_source
+    assert 'policyMode="split"' in run_ttgamma_source
+    assert 'campaignTag="rolepolicy_v2"' in run_ttgamma_source
+    assert 'campaignTag="rolepolicy_v2_run2NloInclusive"' in (
+        run_ttgamma_source
+    )
+    assert "CL007AT_POLICY_MODE" not in run_ttgamma_source
+    assert "TOPEFT_TTGAMMA_SAMPLE_ROLE_POLICY" not in run_ttgamma_source
+
+
+def test_stale_matched_field_names_do_not_reappear():
+    module_source = (
+        REPO_ROOT / "topeft" / "modules" / "ttgamma_photon_history.py"
+    ).read_text()
+    processor_source = (
+        REPO_ROOT / "analysis" / "topeft_run2" / "analysis_processor.py"
+    ).read_text()
+
+    stale_names = (
+        "has_matched_conversion_photon",
+        "n_matched_conversion_photons",
+        "matched_photon_index",
+    )
+    for stale_name in stale_names:
+        assert stale_name not in module_source
+        assert stale_name not in processor_source

--- a/topeft/channels/ch_lst.json
+++ b/topeft/channels/ch_lst.json
@@ -655,52 +655,52 @@
                 ">5"
             ]
         },
-	"3l_fwd": {
-            "lep_chan_lst": [
-                [
-                    "3l_onZ_1b_fwd",
-                    "3l",
-                    "3l_onZ",
-                    "bmask_exactly1m",
-                    "fwdjet_mask"
-                ],
-                [
-                    "3l_onZ_2b_fwd",
-                    "3l",
-                    "3l_onZ",
-                    "bmask_atleast2m",
-                    "fwdjet_mask"
-                ],
-                [
-                    "3l_m_offZ_1b_fwd",
-                    "3l_m",
-                    "3l_offZ",
-                    "bmask_exactly1m",
-                    "fwdjet_mask"
-                ],
-                [
-                    "3l_p_offZ_1b_fwd",
-                    "3l_p",
-                    "3l_offZ",
-                    "bmask_exactly1m",
-                    "fwdjet_mask"
-                ],
-                [
-                    "3l_m_offZ_2b_fwd",
-                    "3l_m",
-                    "3l_offZ",
-                    "bmask_atleast2m",
-                    "fwdjet_mask"
-                ],
+        "3l_fwd": {
+                "lep_chan_lst": [
+                    [
+                        "3l_onZ_1b_fwd",
+                        "3l",
+                        "3l_onZ",
+                        "bmask_exactly1m",
+                        "fwdjet_mask"
+                    ],
+                    [
+                        "3l_onZ_2b_fwd",
+                        "3l",
+                        "3l_onZ",
+                        "bmask_atleast2m",
+                        "fwdjet_mask"
+                    ],
+                    [
+                        "3l_m_offZ_1b_fwd",
+                        "3l_m",
+                        "3l_offZ",
+                        "bmask_exactly1m",
+                        "fwdjet_mask"
+                    ],
+                    [
+                        "3l_p_offZ_1b_fwd",
+                        "3l_p",
+                        "3l_offZ",
+                        "bmask_exactly1m",
+                        "fwdjet_mask"
+                    ],
+                    [
+                        "3l_m_offZ_2b_fwd",
+                        "3l_m",
+                        "3l_offZ",
+                        "bmask_atleast2m",
+                        "fwdjet_mask"
+                    ],
 
-                [
-                    "3l_p_offZ_2b_fwd",
-                    "3l_p",
-                    "3l_offZ",
-                    "bmask_atleast2m",
-                    "fwdjet_mask"
-                ]
-        ],
+                    [
+                        "3l_p_offZ_2b_fwd",
+                        "3l_p",
+                        "3l_offZ",
+                        "bmask_atleast2m",
+                        "fwdjet_mask"
+                    ]
+            ],
             "lep_flav_lst": [
                 "eee",
                 "eem",

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -450,6 +450,7 @@ class DatacardMaker():
         ],
         "convs": [
             "TTGamma_",
+            "TTGJets_",
             "TTG-1Jets_",
             "TTG-1Jets_PTG-100to200_",
             "TTG-1Jets_PTG-10to100_",
@@ -652,7 +653,6 @@ class DatacardMaker():
             "ST_antitop_t-channel", "ST_top_s-channel", "ST_top_t-channel", "tbarW", "tW",
             "TTJets",
             "WJetsToLNu",
-            "TTGJets",  # This is the old low stats convs process, new one should be TTGamma
             # from run3
             "ST_tbarW_Leptonic",
             "ST_tbarW_Semileptonic",
@@ -668,7 +668,6 @@ class DatacardMaker():
             "ZG_MLL-4to50_PTG-200",
             "ZG_MLL-4to50_PTG-100to200",
             "ZG_MLL-50_PTG-400to600", # --> up to here
-            "TTG-1Jets_PTG-200",
             "DYJetsToLL_MLL-50",
             # "TTGamma",
             # "WWTo2L2Nu","ZZTo4L",#"WZTo3LNu",

--- a/topeft/modules/ttgamma_photon_history.py
+++ b/topeft/modules/ttgamma_photon_history.py
@@ -1,0 +1,639 @@
+"""Diagnostics for photons recovered from selected conversion-like leptons.
+
+Recovered means that a gen photon was found. Classified origin means that the
+recovered photon has a clean decay or production ancestry; hadron and ambiguous
+guard categories are intentionally excluded from classified origin.
+"""
+
+import re
+
+import awkward as ak
+import numpy as np
+
+
+NOT_CONVERSION = 0
+DECAY_LEPTON = 1
+DECAY_W_OR_B_WITH_TOP_ANCESTOR = 2
+DECAY_TOP_COPY_CONDITION = 3
+PRODUCTION_ISR = 4
+PRODUCTION_OFFSHELL_TOP = 5
+HADRON_ANCESTOR = 6
+AMBIGUOUS = 7
+NO_PHOTON_FOUND = 8
+INVALID_MATCH = 9
+
+CATEGORY_NAMES = {
+    NOT_CONVERSION: "not_conversion",
+    DECAY_LEPTON: "decay_lepton",
+    DECAY_W_OR_B_WITH_TOP_ANCESTOR: "decay_w_or_b_with_top_ancestor",
+    DECAY_TOP_COPY_CONDITION: "decay_top_copy_condition",
+    PRODUCTION_ISR: "production_isr",
+    PRODUCTION_OFFSHELL_TOP: "production_offshell_top",
+    HADRON_ANCESTOR: "hadron_ancestor",
+    AMBIGUOUS: "ambiguous_no_mother_or_malformed_chain",
+    NO_PHOTON_FOUND: "no_photon_found",
+    INVALID_MATCH: "invalid_match",
+}
+
+DECAY_CATEGORIES = (
+    DECAY_LEPTON,
+    DECAY_W_OR_B_WITH_TOP_ANCESTOR,
+    DECAY_TOP_COPY_CONDITION,
+)
+PRODUCTION_CATEGORIES = (PRODUCTION_ISR, PRODUCTION_OFFSHELL_TOP)
+
+EVENT_DIAGNOSTIC_PREFIX = "ttgamma_photon_history_"
+DEFAULT_MAX_ANCESTRY_DEPTH = 64
+
+TTGAMMA_PRODUCTION_SAMPLE = "ttgamma_production"
+TTGAMMA_DECAY_SAMPLE = "ttgamma_decay"
+TTGAMMA_INCLUSIVE_SAMPLE = "ttgamma_inclusive"
+INCLUSIVE_TTBAR_SAMPLE = "inclusive_ttbar"
+OTHER_SAMPLE = "other"
+
+SPLIT_SAMPLE_ROLE_POLICY = "split"
+RUN2_NLO_INCLUSIVE_SAMPLE_ROLE_POLICY = "run2_nlo_inclusive"
+SUPPORTED_SAMPLE_ROLE_POLICIES = (
+    SPLIT_SAMPLE_ROLE_POLICY,
+    RUN2_NLO_INCLUSIVE_SAMPLE_ROLE_POLICY,
+)
+
+_RUN2_ERA = r"(?:UL16APV|UL16|UL17|UL18)"
+_RUN3_ERA = r"(?:2022EE|2022|2023BPix|2023)"
+_TTGAMMA_PRODUCTION_SAMPLE_PATTERN = re.compile(
+    rf"(?:{_RUN2_ERA}_TTGJets(?:_NDSkim)?|TTGJets_central{_RUN2_ERA})"
+)
+_TTGAMMA_DECAY_SAMPLE_PATTERN = re.compile(
+    rf"(?:{_RUN2_ERA}_TTGamma_(?:Dilept|SingleLept)(?:_NDSkim)?"
+    rf"|TTGamma_central{_RUN2_ERA})"
+)
+_TTGAMMA_INCLUSIVE_SAMPLE_PATTERN = re.compile(
+    rf"(?:TTG-1Jets_PTG-(?:10to100|100to200|200)"
+    rf"(?:_NDSkim)?_{_RUN3_ERA}"
+    rf"|TTG-1Jets_PTG-(?:10to100|100to200|200)_central{_RUN3_ERA}"
+    rf"|TTGamma_central{_RUN3_ERA})"
+)
+_INCLUSIVE_TTBAR_SAMPLE_PATTERN = re.compile(
+    rf"(?:{_RUN2_ERA}_(?:TTTo2L2Nu|TTToSemiLeptonic|TTToHadronic|TTJets)"
+    rf"(?:_NDSkim)?"
+    rf"|(?:TTTo2L2Nu|TTToSemiLeptonic|TTToHadronic|TTJets)"
+    rf"_central{_RUN2_ERA}"
+    rf"|(?:TTto2L2Nu(?:-[23]Jets)?|TTtoLNu2Q|TTto4Q)"
+    rf"(?:_NDSkim)?_{_RUN3_ERA}"
+    rf"|(?:TTto2L2Nu|TTtoLNu2Q|TTto4Q)_central{_RUN3_ERA})"
+)
+
+
+def get_ttgamma_sample_role_policy(
+    sample_role_policy=SPLIT_SAMPLE_ROLE_POLICY,
+):
+    """Return the configured ttgamma sample-role policy."""
+
+    policy = sample_role_policy
+    if policy not in SUPPORTED_SAMPLE_ROLE_POLICIES:
+        supported = ", ".join(SUPPORTED_SAMPLE_ROLE_POLICIES)
+        raise ValueError(
+            f"Unsupported ttgamma sample-role policy {policy!r}; "
+            f"supported values are: {supported}"
+        )
+    return policy
+
+
+def _zeros_like_objects(selected_leptons, dtype):
+    return ak.values_astype(
+        ak.zeros_like(ak.local_index(selected_leptons, axis=1)),
+        dtype,
+    )
+
+
+def _full_like_objects(selected_leptons, value, dtype=np.int64):
+    return _zeros_like_objects(selected_leptons, dtype) + value
+
+
+def _zeros_like_events(selected_leptons, dtype):
+    return ak.values_astype(
+        ak.zeros_like(ak.num(selected_leptons, axis=1)),
+        dtype,
+    )
+
+
+def _full_like_events(selected_leptons, value, dtype=np.bool_):
+    return _zeros_like_events(selected_leptons, dtype) + value
+
+
+def classify_conversion_overlap_sample(
+    sample_name,
+    sample_role_policy=SPLIT_SAMPLE_ROLE_POLICY,
+):
+    """Classify a dataset-basename key for conversion overlap removal."""
+
+    normalized_name = str(sample_name).rsplit("/", 1)[-1]
+    if normalized_name.endswith(".json"):
+        normalized_name = normalized_name[:-5]
+    policy = get_ttgamma_sample_role_policy(sample_role_policy)
+    if (
+        policy == RUN2_NLO_INCLUSIVE_SAMPLE_ROLE_POLICY
+        and _TTGAMMA_PRODUCTION_SAMPLE_PATTERN.fullmatch(normalized_name)
+    ):
+        return TTGAMMA_INCLUSIVE_SAMPLE
+    if _TTGAMMA_PRODUCTION_SAMPLE_PATTERN.fullmatch(normalized_name):
+        return TTGAMMA_PRODUCTION_SAMPLE
+    if _TTGAMMA_DECAY_SAMPLE_PATTERN.fullmatch(normalized_name):
+        return TTGAMMA_DECAY_SAMPLE
+    if _TTGAMMA_INCLUSIVE_SAMPLE_PATTERN.fullmatch(normalized_name):
+        return TTGAMMA_INCLUSIVE_SAMPLE
+    if _INCLUSIVE_TTBAR_SAMPLE_PATTERN.fullmatch(normalized_name):
+        return INCLUSIVE_TTBAR_SAMPLE
+    return OTHER_SAMPLE
+
+
+def attach_conversion_overlap_removal_diagnostics(
+    events,
+    sample_name,
+    is_data=False,
+    sample_role_policy=SPLIT_SAMPLE_ROLE_POLICY,
+):
+    """Attach nominal ttgamma/ttbar conversion-overlap removal flags."""
+
+    decay = ak.values_astype(
+        ak.fill_none(
+            events[
+                f"{EVENT_DIAGNOSTIC_PREFIX}"
+                "has_decay_origin_conversion_photon"
+            ],
+            False,
+        ),
+        np.bool_,
+    )
+    production = ak.values_astype(
+        ak.fill_none(
+            events[
+                f"{EVENT_DIAGNOSTIC_PREFIX}"
+                "has_production_origin_conversion_photon"
+            ],
+            False,
+        ),
+        np.bool_,
+    )
+    has_selected_conversion_lepton = ak.values_astype(
+        ak.fill_none(
+            events[
+                f"{EVENT_DIAGNOSTIC_PREFIX}"
+                "has_selected_conversion_lepton"
+            ],
+            False,
+        ),
+        np.bool_,
+    )
+    sample_class = (
+        OTHER_SAMPLE
+        if is_data
+        else classify_conversion_overlap_sample(
+            sample_name,
+            sample_role_policy=sample_role_policy,
+        )
+    )
+
+    false_events = ak.zeros_like(decay, dtype=np.bool_)
+    true_events = ~false_events
+    is_ttgamma_production = (
+        true_events
+        if sample_class == TTGAMMA_PRODUCTION_SAMPLE
+        else false_events
+    )
+    is_ttgamma_decay = (
+        true_events
+        if sample_class == TTGAMMA_DECAY_SAMPLE
+        else false_events
+    )
+    is_ttgamma_inclusive = (
+        true_events
+        if sample_class == TTGAMMA_INCLUSIVE_SAMPLE
+        else false_events
+    )
+    is_inclusive_ttbar = (
+        true_events
+        if sample_class == INCLUSIVE_TTBAR_SAMPLE
+        else false_events
+    )
+    removed_ttgamma_production_role_decay_origin = (
+        decay if sample_class == TTGAMMA_PRODUCTION_SAMPLE else false_events
+    )
+    removed_ttgamma_decay_role_production_origin = (
+        production if sample_class == TTGAMMA_DECAY_SAMPLE else false_events
+    )
+    removed_ttbar_selected_external_conversion = (
+        has_selected_conversion_lepton
+        if sample_class == INCLUSIVE_TTBAR_SAMPLE
+        else false_events
+    )
+    removed = (
+        removed_ttgamma_production_role_decay_origin
+        | removed_ttgamma_decay_role_production_origin
+        | removed_ttbar_selected_external_conversion
+    )
+    result = {
+        "pass_conversion_overlap_removal": ~removed,
+        "removed_by_conversion_overlap_removal": removed,
+        "removed_ttgamma_production_role_decay_origin": (
+            removed_ttgamma_production_role_decay_origin
+        ),
+        "removed_ttgamma_decay_role_production_origin": (
+            removed_ttgamma_decay_role_production_origin
+        ),
+        "removed_ttbar_selected_external_conversion": (
+            removed_ttbar_selected_external_conversion
+        ),
+        "sample_role_is_ttgamma_production": is_ttgamma_production,
+        "sample_role_is_ttgamma_decay": is_ttgamma_decay,
+        "sample_role_is_ttgamma_inclusive": is_ttgamma_inclusive,
+        "sample_role_is_inclusive_ttbar": is_inclusive_ttbar,
+        "has_mixed_decay_and_production_conversion_photons": (
+            decay & production
+        ),
+    }
+    for field, values in result.items():
+        events[f"{EVENT_DIAGNOSTIC_PREFIX}{field}"] = values
+    return result
+
+
+def _has_required_fields(genparts, selected_leptons):
+    if genparts is None or selected_leptons is None:
+        return False
+    return (
+        {"pdgId", "genPartIdxMother"} <= set(ak.fields(genparts))
+        and {"genPartFlav", "genPartIdx"} <= set(ak.fields(selected_leptons))
+    )
+
+
+def _broadcast_genpart_count(genparts, indices):
+    return ak.broadcast_arrays(ak.num(genparts, axis=1), indices)[0]
+
+
+def _valid_index(genparts, indices):
+    return (indices >= 0) & (indices < _broadcast_genpart_count(genparts, indices))
+
+
+def _take_genpart_field(genparts, indices, field, default):
+    valid = _valid_index(genparts, indices)
+    masked_indices = ak.mask(indices, valid)
+    return ak.fill_none(genparts[masked_indices][field], default)
+
+
+def _category_mask(categories, accepted):
+    mask = ak.zeros_like(categories, dtype=np.bool_)
+    for category in accepted:
+        mask = mask | (categories == category)
+    return mask
+
+
+def _repeated_index(history, current, active):
+    if history is None:
+        return ak.zeros_like(active)
+    return active & ak.any(
+        history == current,
+        axis=2,
+    )
+
+
+def _append_history(history, current):
+    current_step = ak.singletons(current)
+    if history is None:
+        return current_step
+    return ak.concatenate([history, current_step], axis=2)
+
+
+def _empty_result(selected_leptons, missing_branches):
+    categories = _full_like_objects(selected_leptons, NOT_CONVERSION)
+    indices = _full_like_objects(selected_leptons, -1)
+    false_objects = _zeros_like_objects(selected_leptons, np.bool_)
+    false_events = _zeros_like_events(selected_leptons, np.bool_)
+    zero_counts = _zeros_like_events(selected_leptons, np.int64)
+
+    return {
+        "lepton": {
+            "category": categories,
+            "recovered_photon_index": indices,
+            "first_copy_photon_index": indices,
+            "is_selected_conversion_lepton": false_objects,
+            "has_recovered_conversion_photon": false_objects,
+        },
+        "event": {
+            "diagnostic_missing_branches": _full_like_events(
+                selected_leptons, missing_branches
+            ),
+            "has_selected_conversion_lepton": false_events,
+            "has_recovered_conversion_photon": false_events,
+            "has_classified_origin_conversion_photon": false_events,
+            "has_decay_origin_conversion_photon": false_events,
+            "has_production_origin_conversion_photon": false_events,
+            "has_hadron_ancestor_conversion_photon": false_events,
+            "has_ambiguous_conversion_photon": false_events,
+            "has_no_photon_found_conversion_lepton": false_events,
+            "has_invalid_match_conversion_lepton": false_events,
+            "n_selected_conversion_leptons": zero_counts,
+            "n_recovered_conversion_photons": zero_counts,
+            "n_classified_origin_conversion_photons": zero_counts,
+            "n_decay_origin_conversion_photons": zero_counts,
+            "n_production_origin_conversion_photons": zero_counts,
+            "n_hadron_ancestor_conversion_photons": zero_counts,
+            "n_ambiguous_conversion_photons": zero_counts,
+            "n_no_photon_found_conversion_leptons": zero_counts,
+            "n_invalid_match_conversion_leptons": zero_counts,
+        },
+    }
+
+
+def _recover_photon_indices(genparts, selected_leptons, max_depth):
+    is_conversion = selected_leptons.genPartFlav == 22
+    initial_indices = selected_leptons.genPartIdx
+    initial_valid = _valid_index(genparts, initial_indices)
+
+    current = ak.where(initial_valid, initial_indices, -1)
+    found = _full_like_objects(selected_leptons, -1)
+    malformed = is_conversion & ~initial_valid
+    active = is_conversion & initial_valid
+    history = None
+
+    for _ in range(max_depth):
+        if not bool(ak.any(active)):
+            break
+        repeated = _repeated_index(history, current, active)
+        malformed = malformed | repeated
+        active = active & ~repeated
+
+        valid = _valid_index(genparts, current)
+        invalid = active & (current != -1) & ~valid
+        malformed = malformed | invalid
+        active = active & valid
+
+        pdg_id = _take_genpart_field(genparts, current, "pdgId", 0)
+        found_now = active & (abs(pdg_id) == 22)
+        found = ak.where(found_now, current, found)
+        active = active & ~found_now
+
+        history = _append_history(history, current)
+        mother = _take_genpart_field(
+            genparts, current, "genPartIdxMother", -1
+        )
+        active = active & (mother != -1)
+        current = mother
+
+    malformed = malformed | active
+    return is_conversion, found, malformed
+
+
+def _first_photon_copy(genparts, photon_indices, max_depth):
+    first_copy = photon_indices
+    active = photon_indices >= 0
+    malformed = ak.zeros_like(active)
+    history = None
+
+    for _ in range(max_depth):
+        if not bool(ak.any(active)):
+            break
+        repeated = _repeated_index(history, first_copy, active)
+        malformed = malformed | repeated
+        active = active & ~repeated
+
+        mother = _take_genpart_field(
+            genparts, first_copy, "genPartIdxMother", -1
+        )
+        mother_valid = _valid_index(genparts, mother)
+        invalid = active & (mother != -1) & ~mother_valid
+        malformed = malformed | invalid
+
+        mother_pdg_id = _take_genpart_field(genparts, mother, "pdgId", 0)
+        same_pdg_mother = active & mother_valid & (abs(mother_pdg_id) == 22)
+        history = _append_history(history, first_copy)
+        first_copy = ak.where(same_pdg_mother, mother, first_copy)
+        active = same_pdg_mother
+
+    malformed = malformed | active
+    return first_copy, malformed
+
+
+def _photon_ancestry(genparts, photon_indices, max_depth):
+    mother = _take_genpart_field(
+        genparts, photon_indices, "genPartIdxMother", -1
+    )
+    mother_valid = _valid_index(genparts, mother)
+    mother_pdg_id = _take_genpart_field(genparts, mother, "pdgId", 0)
+    grandmother = _take_genpart_field(
+        genparts, mother, "genPartIdxMother", -1
+    )
+    grandmother_pdg_id = _take_genpart_field(
+        genparts, grandmother, "pdgId", 0
+    )
+
+    active = (photon_indices >= 0) & mother_valid
+    malformed = (photon_indices >= 0) & (mother != -1) & ~mother_valid
+    has_top = ak.zeros_like(active)
+    has_hadron = ak.zeros_like(active)
+    current = mother
+    history = None
+
+    for _ in range(max_depth):
+        if not bool(ak.any(active)):
+            break
+        repeated = _repeated_index(history, current, active)
+        malformed = malformed | repeated
+        active = active & ~repeated
+
+        valid = _valid_index(genparts, current)
+        invalid = active & (current != -1) & ~valid
+        malformed = malformed | invalid
+        active = active & valid
+
+        pdg_id = abs(_take_genpart_field(genparts, current, "pdgId", 0))
+        has_top = has_top | (active & (pdg_id == 6))
+        has_hadron = has_hadron | (
+            active & (pdg_id > 37) & (pdg_id != 2212)
+        )
+
+        history = _append_history(history, current)
+        next_mother = _take_genpart_field(
+            genparts, current, "genPartIdxMother", -1
+        )
+        active = active & (next_mother != -1)
+        current = next_mother
+
+    malformed = malformed | active
+    no_mother = (photon_indices >= 0) & (mother == -1)
+    return {
+        "mother_pdg_id": mother_pdg_id,
+        "grandmother_pdg_id": grandmother_pdg_id,
+        "has_top": has_top,
+        "has_hadron": has_hadron,
+        "malformed": malformed,
+        "no_mother": no_mother,
+    }
+
+
+def _classify_photons(
+    genparts,
+    is_conversion,
+    recovered_photon_indices,
+    recovery_malformed,
+    max_depth,
+):
+    categories = _full_like_objects(is_conversion, NOT_CONVERSION)
+    no_match = is_conversion & (recovered_photon_indices < 0)
+    categories = ak.where(
+        no_match & recovery_malformed, INVALID_MATCH, categories
+    )
+    categories = ak.where(
+        no_match & ~recovery_malformed, NO_PHOTON_FOUND, categories
+    )
+
+    first_copy, first_copy_malformed = _first_photon_copy(
+        genparts, recovered_photon_indices, max_depth
+    )
+    ancestry = _photon_ancestry(genparts, first_copy, max_depth)
+    recovered = is_conversion & (recovered_photon_indices >= 0)
+    ambiguous = recovered & (
+        first_copy_malformed
+        | ancestry["malformed"]
+        | ancestry["no_mother"]
+    )
+
+    mother_abs = abs(ancestry["mother_pdg_id"])
+    decay_lepton = recovered & (
+        (mother_abs == 11) | (mother_abs == 13) | (mother_abs == 15)
+    )
+    decay_w_or_b = (
+        recovered
+        & ((mother_abs == 24) | (mother_abs == 5))
+        & ancestry["has_top"]
+    )
+    decay_top_copy = (
+        recovered
+        & (mother_abs == 6)
+        & (
+            ancestry["grandmother_pdg_id"]
+            == ancestry["mother_pdg_id"]
+        )
+    )
+    offshell_top = recovered & (
+        ((mother_abs == 6) & ~decay_top_copy) | (mother_abs == 21)
+    )
+    decay_any = decay_lepton | decay_w_or_b | decay_top_copy
+    production_isr = recovered & ~decay_any & ~offshell_top
+
+    categories = ak.where(production_isr, PRODUCTION_ISR, categories)
+    categories = ak.where(offshell_top, PRODUCTION_OFFSHELL_TOP, categories)
+    categories = ak.where(
+        decay_top_copy, DECAY_TOP_COPY_CONDITION, categories
+    )
+    categories = ak.where(
+        decay_w_or_b, DECAY_W_OR_B_WITH_TOP_ANCESTOR, categories
+    )
+    categories = ak.where(decay_lepton, DECAY_LEPTON, categories)
+    categories = ak.where(
+        recovered & ancestry["has_hadron"], HADRON_ANCESTOR, categories
+    )
+    categories = ak.where(ambiguous, AMBIGUOUS, categories)
+    return categories, first_copy
+
+
+def _event_reduction(selected_leptons, categories, missing_branches=False):
+    is_conversion = selected_leptons.genPartFlav == 22
+    decay = _category_mask(categories, DECAY_CATEGORIES)
+    production = _category_mask(categories, PRODUCTION_CATEGORIES)
+    classified_origin = decay | production
+    hadron = categories == HADRON_ANCESTOR
+    ambiguous = categories == AMBIGUOUS
+    recovered = classified_origin | hadron | ambiguous
+    no_photon = categories == NO_PHOTON_FOUND
+    invalid = categories == INVALID_MATCH
+
+    return {
+        "diagnostic_missing_branches": _full_like_events(
+            selected_leptons, missing_branches
+        ),
+        "has_selected_conversion_lepton": ak.any(is_conversion, axis=1),
+        "has_recovered_conversion_photon": ak.any(recovered, axis=1),
+        "has_classified_origin_conversion_photon": ak.any(
+            classified_origin, axis=1
+        ),
+        "has_decay_origin_conversion_photon": ak.any(decay, axis=1),
+        "has_production_origin_conversion_photon": ak.any(
+            production, axis=1
+        ),
+        "has_hadron_ancestor_conversion_photon": ak.any(hadron, axis=1),
+        "has_ambiguous_conversion_photon": ak.any(ambiguous, axis=1),
+        "has_no_photon_found_conversion_lepton": ak.any(no_photon, axis=1),
+        "has_invalid_match_conversion_lepton": ak.any(invalid, axis=1),
+        "n_selected_conversion_leptons": ak.sum(is_conversion, axis=1),
+        "n_recovered_conversion_photons": ak.sum(recovered, axis=1),
+        "n_classified_origin_conversion_photons": ak.sum(
+            classified_origin, axis=1
+        ),
+        "n_decay_origin_conversion_photons": ak.sum(decay, axis=1),
+        "n_production_origin_conversion_photons": ak.sum(
+            production, axis=1
+        ),
+        "n_hadron_ancestor_conversion_photons": ak.sum(hadron, axis=1),
+        "n_ambiguous_conversion_photons": ak.sum(ambiguous, axis=1),
+        "n_no_photon_found_conversion_leptons": ak.sum(no_photon, axis=1),
+        "n_invalid_match_conversion_leptons": ak.sum(invalid, axis=1),
+    }
+
+
+def classify_selected_conversion_photon_history(
+    genparts,
+    selected_leptons,
+    max_depth=DEFAULT_MAX_ANCESTRY_DEPTH,
+):
+    """Classify gen-photon history for selected FO conversion-like leptons.
+
+    The result contains jagged lepton-level arrays and flat event-level
+    diagnostic reductions. It does not make or apply an event-selection
+    decision.
+    """
+
+    if max_depth < 1:
+        raise ValueError("max_depth must be at least 1")
+    if selected_leptons is None:
+        raise ValueError("selected_leptons is required")
+    if not _has_required_fields(genparts, selected_leptons):
+        return _empty_result(selected_leptons, missing_branches=True)
+
+    is_conversion, recovered_photon_indices, recovery_malformed = (
+        _recover_photon_indices(genparts, selected_leptons, max_depth)
+    )
+    categories, first_copy_indices = _classify_photons(
+        genparts,
+        is_conversion,
+        recovered_photon_indices,
+        recovery_malformed,
+        max_depth,
+    )
+    has_recovered_photon = is_conversion & (recovered_photon_indices >= 0)
+
+    return {
+        "lepton": {
+            "category": categories,
+            "recovered_photon_index": recovered_photon_indices,
+            "first_copy_photon_index": first_copy_indices,
+            "is_selected_conversion_lepton": is_conversion,
+            "has_recovered_conversion_photon": has_recovered_photon,
+        },
+        "event": _event_reduction(selected_leptons, categories),
+    }
+
+
+def attach_photon_history_diagnostics(events, selected_leptons, genparts=None):
+    """Attach photon-history fields and return the decorated leptons."""
+
+    result = classify_selected_conversion_photon_history(
+        genparts, selected_leptons
+    )
+    leptons = selected_leptons
+    for field, values in result["lepton"].items():
+        leptons = ak.with_field(
+            leptons, values, f"conversion_photon_history_{field}"
+        )
+    for field, values in result["event"].items():
+        events[f"{EVENT_DIAGNOSTIC_PREFIX}{field}"] = values
+    return leptons

--- a/topeft/modules/yield_tools.py
+++ b/topeft/modules/yield_tools.py
@@ -67,7 +67,25 @@ class YieldTools():
                     "NonPrompt2023BPix",
                 )
             ],
-            "conv"  : ["TTGamma_centralUL16"  ,"TTGamma_centralUL16APV"  ,"TTGamma_centralUL17"  ,"TTGamma_centralUL18"  ,"TTGamma_central2022", "TTGamma_central2022EE", "TTGamma_central2023", "TTGamma_central2023BPix"],
+            "conv"  : [
+                "TTGJets_centralUL16",
+                "TTGJets_centralUL16APV",
+                "TTGJets_centralUL17",
+                "TTGJets_centralUL18",
+                "TTGamma_centralUL16",
+                "TTGamma_centralUL16APV",
+                "TTGamma_centralUL17",
+                "TTGamma_centralUL18",
+                "TTGamma_central2022",
+                "TTGamma_central2022EE",
+                "TTGamma_central2023",
+                "TTGamma_central2023BPix",
+                *[
+                    f"TTG-1Jets_PTG-{pt_bin}_central{year}"
+                    for year in ("2022", "2022EE", "2023", "2023BPix")
+                    for pt_bin in ("10to100", "100to200", "200")
+                ],
+            ],
             "WW"    : ["WWTo2L2Nu_centralUL16","WWTo2L2Nu_centralUL16APV","WWTo2L2Nu_centralUL17","WWTo2L2Nu_centralUL18","WWTo2L2Nu_central2022", "WWTo2L2Nu_central2022EE", "WWTo2L2Nu_central2023", "WWTo2L2Nu_central2023BPix"],
             "WZ"    : ["WZTo3LNu_centralUL16" ,"WZTo3LNu_centralUL16APV" ,"WZTo3LNu_centralUL17" ,"WZTo3LNu_centralUL18","WZTo3LNu_central2022","WZTo3LNu_central2022EE", "WZTo3LNu_central2023", "WZTo3LNu_central2023BPix"],
             "ZZ"    : ["ZZTo4L_centralUL16"   ,"ZZTo4L_centralUL16APV"   ,"ZZTo4L_centralUL17"   ,"ZZTo4L_centralUL18"   ,"ZZTo4L_central2022", "ZZTo4L_central2022EE",  "ZZTo4L_central2023",  "ZZTo4L_central2023BPix"],
@@ -856,4 +874,3 @@ class YieldTools():
 
             print_ratios(yld_sum_dict["ee"],yld_sum_dict["mm"],2)
             print_ratios(yld_sum_dict["eee"],yld_sum_dict["mmm"],3)
-


### PR DESCRIPTION
### Summary

- Add generator-photon-history diagnostics for selected external-conversion-like leptons.
- Apply sample-role-dependent ttgamma / inclusive-ttbar conversion-overlap removal in the processor event selection.
- Add an explicit `--ttgamma-sample-role-policy` option with nominal default `split` and diagnostic `run2_nlo_inclusive` mode.
- Update Run 2 background cfgs, conversion-process grouping, and workflow helpers to use the agreed ttgamma strategy.
- Add focused tests covering photon-history classification, sample-role classification, overlap-removal behavior, and default-policy propagation.

### Motivation

The analysis needs an explicit and reproducible treatment for selected external-conversion-like leptons that can otherwise be double counted between inclusive ttbar and dedicated ttgamma samples.

The intended nominal strategy is sample-role based:

- Run 2 `TTGJets` is used for production-like ttgamma photons.
- Run 2 `TTGamma_Dilept` and `TTGamma_SingleLept` are used for decay-like ttgamma photons.
- Run 3 `TTG-1Jets_PTG-*` samples are treated inclusively, since no corresponding dedicated Run 3 LO decay ttgamma samples are available.
- Inclusive ttbar samples veto events with selected external-conversion-like leptons.

This PR makes that policy explicit in the processor, configurable from the CLI, visible in wrapper logs, and covered by focused tests.

### Implementation details

#### A. Photon-history diagnostics

Adds `topeft/modules/ttgamma_photon_history.py`.

The new module classifies generator-photon history for selected FO leptons with `genPartFlav == 22`. It provides lepton-level and event-level diagnostics, including:

```text
not_conversion
decay_lepton
decay_w_or_b_with_top_ancestor
decay_top_copy_condition
production_isr
production_offshell_top
hadron_ancestor
ambiguous_no_mother_or_malformed_chain
no_photon_found
invalid_match
````

The main public helpers are:

```python
attach_photon_history_diagnostics(...)
attach_conversion_overlap_removal_diagnostics(...)
classify_conversion_overlap_sample(...)
classify_selected_conversion_photon_history(...)
get_ttgamma_sample_role_policy(...)
```

Guard categories such as hadron-ancestor, ambiguous, no-photon-found, and invalid-match are retained as diagnostics but do not drive nominal ttgamma role vetoes.

#### B. Sample-role policy

The nominal policy is:

```python
SPLIT_SAMPLE_ROLE_POLICY = "split"
```

The explicit diagnostic policy is:

```python
RUN2_NLO_INCLUSIVE_SAMPLE_ROLE_POLICY = "run2_nlo_inclusive"
```

Under the nominal `split` policy, samples are classified as:

```text
Run 2 TTGJets        -> ttgamma_production
Run 2 TTGamma        -> ttgamma_decay
Run 3 TTG-1Jets_PTG  -> ttgamma_inclusive
inclusive ttbar      -> inclusive_ttbar
```

The corresponding event-removal semantics are:

```text
ttgamma_production:
  remove decay-origin selected conversion photons

ttgamma_decay:
  remove production-origin selected conversion photons

ttgamma_inclusive:
  keep both production-origin and decay-origin classified photons

inclusive_ttbar:
  remove events with selected external-conversion-like leptons
```

For the diagnostic `run2_nlo_inclusive` policy, Run 2 `TTGJets` is treated inclusively while inclusive ttbar still vetoes selected external-conversion-like leptons.

#### C. Processor integration

Updates `analysis/topeft_run2/analysis_processor.py`.

The processor now:

* imports the new photon-history helpers;
* accepts `ttgamma_sample_role_policy="split"` in the constructor;
* validates and stores the resolved policy;
* decorates FO leptons with photon-history diagnostics after cone-pt sorting;
* attaches event-level conversion-overlap-removal diagnostics;
* applies `ttgamma_photon_history_pass_conversion_overlap_removal` in the final event mask.

This is a physics/analysis semantics change: selected external-conversion-like overlap removal is now part of the event selection.

#### D. Runtime CLI and wrapper propagation

Updates `analysis/topeft_run2/run_analysis.py`.

Adds:

```bash
--ttgamma-sample-role-policy {split,run2_nlo_inclusive}
```

Default:

```bash
split
```

The resolved value is validated, printed in the run log, propagated to `AnalysisProcessor`, and included in deferred NP metadata.

Updates `analysis/topeft_run2/fullR3_run.sh`.

The wrapper now:

* defaults to `TTGAMMA_SAMPLE_ROLE_POLICY="split"`;
* accepts both `--ttgamma-sample-role-policy split` and `--ttgamma-sample-role-policy=split`;
* accepts the explicit diagnostic value `run2_nlo_inclusive`;
* rejects unsupported values early;
* prints the resolved policy;
* always forwards the resolved policy to `run_analysis.py`.

This means both direct `run_analysis.py` users and `fullR3_run.sh` users get the nominal `split` policy by default.

#### E. Sample cfg and process-grouping updates

Updates `input_samples/cfgs/mc_background_samples_NDSkim.cfg`.

The Run 2 background cfg now includes the intended split ttgamma composition for each UL era:

```text
TTGJets
TTGamma_Dilept
TTGamma_SingleLept
```

Updates `topeft/modules/yield_tools.py`.

The conversion group now includes:

* Run 2 `TTGJets_centralUL*`;
* Run 2 `TTGamma_centralUL*`;
* Run 3 `TTG-1Jets_PTG-*_central{2022,2022EE,2023,2023BPix}`.

Updates `topeft/modules/datacard_tools.py`.

The conversion-process grouping now includes `TTGJets_` and no longer ignores active Run 3 `TTG-1Jets_PTG-200`.

#### F. Workflow helpers

Adds `analysis/topeft_run2/run_ttgamma.sh`.

This helper builds reduced ttgamma/ttbar cfgs for focused SR validation and production checks.

Nominal mode:

```bash
./run_ttgamma.sh
```

uses:

```text
policy: split
tag: rolepolicy_v2
```

Diagnostic mode:

```bash
./run_ttgamma.sh --ttgamma-sample-role-policy run2_nlo_inclusive
```

uses:

```text
policy: run2_nlo_inclusive
tag: rolepolicy_v2_run2NloInclusive
```

Updates `analysis/topeft_run2/run_cr.sh`.

The helper now explicitly sets:

```bash
ttgamma_sample_role_policy="split"
campaign_tag="rolepolicy_v2"
```

and forwards:

```bash
--ttgamma-sample-role-policy "${ttgamma_sample_role_policy}"
```

to `fullR3_run.sh`.

By default this helper currently has:

```bash
run_cr=false
run_sr=true
```

so despite the filename, it runs the SR blocks unless `run_cr` is enabled.

#### G. Incidental/non-physics changes

This diff also includes:

* a commented Work Queue memory hint change in `run_analysis.py` from `4000` to `16000`;
* whitespace-only reformatting around `3l_fwd` in `topeft/channels/ch_lst.json`.

These are not part of the ttgamma physics semantics. Reviewers can treat them as incidental unless they are split out before opening the PR.

### Testing

Focused unit tests:

```bash
/users/apiccine/work/correction-lib/codex-run.sh /bin/bash --noprofile --norc -c \
  'cd /users/apiccine/work/correction-lib/topeft && \
   /users/apiccine/work/miniconda3/envs/clib-env/bin/python -m pytest -q tests/test_ttgamma_photon_history.py'
```

Result:

```text
151 passed, 1 warning
```

Compile check:

```bash
/users/apiccine/work/correction-lib/codex-run.sh /bin/bash --noprofile --norc -c \
  'cd /users/apiccine/work/correction-lib/topeft && \
   /users/apiccine/work/miniconda3/envs/clib-env/bin/python -m compileall -q \
     topeft/modules/ttgamma_photon_history.py \
     analysis/topeft_run2/analysis_processor.py \
     analysis/topeft_run2/run_analysis.py \
     tests/test_ttgamma_photon_history.py'
```

Result:

```text
passed
```

Shell syntax checks:

```bash
bash -n analysis/topeft_run2/fullR3_run.sh
bash -n analysis/topeft_run2/run_ttgamma.sh
bash -n analysis/topeft_run2/run_cr.sh
```

Result:

```text
passed
```

Dry-run checks confirmed:

```text
fullR3_run.sh resolves and forwards --ttgamma-sample-role-policy split
run_ttgamma.sh nominal mode uses rolepolicy_v2
run_ttgamma.sh diagnostic mode uses rolepolicy_v2_run2NloInclusive
```

No full production campaign is claimed in this PR.

### Review notes

* This PR intentionally changes analysis semantics by applying selected external-conversion-like overlap removal in the processor event mask.
* The nominal policy is `split`; `run2_nlo_inclusive` is diagnostic only and must be requested explicitly.
* The policy flag classifies and filters samples already present in the cfg. It does not add missing samples by itself.
* For Run 2, the cfg must include both `TTGJets` and `TTGamma_Dilept` / `TTGamma_SingleLept` for the full split strategy to be represented.
* For Run 3, `TTG-1Jets_PTG-*` is treated inclusively because no dedicated Run 3 LO decay ttgamma sample is used here.
* The inclusive ttbar veto is based on selected external-conversion-like leptons, not only on recovered/classified photon ancestry.
* Please review the sample-name regexes in `ttgamma_photon_history.py` carefully; these define which datasets receive role-dependent treatment.
* Please confirm whether the commented `run_analysis.py` Work Queue memory hint and the `ch_lst.json` whitespace-only reformat should stay in this PR or be split out.
* `run_ttgamma.sh` currently uses CamelCase helper names. This is not a runtime issue, but it is inconsistent with the newer preferred `snake_case` style for helper functions.