### PR TITLE
Align JME jet corrections and Run 3 jet veto-map inputs

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -88,6 +88,23 @@ def derive_analysis_enable_toggles(offz_3l_split, tau_h_analysis, fwd_analysis, 
     }
 
 
+def get_veto_map_input_jets(cleaned_jets, year, is_run3):
+    if not is_run3:
+        return cleaned_jets
+
+    jet_id_mask = tc_os.run3_nanoV12_ak4puppi_jet_id(
+        cleaned_jets,
+        year,
+        working_point="tight_lepton_veto",
+    )
+    em_fraction_mask = (cleaned_jets.chEmEF + cleaned_jets.neEmEF) < 0.9
+    return cleaned_jets[
+        (cleaned_jets.pt > 15.0)
+        & jet_id_mask
+        & em_fraction_mask
+    ]
+
+
 def resolve_category_dict_names(offz_3l_split, tau_h_analysis, fwd_analysis, all_analysis):
     if all_analysis:
         sr_dict_name = "ALL_CH_LST_SR"
@@ -949,7 +966,8 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Jet Veto Maps
             # Removes events that have ANY jet in a specific eta-phi space (not required for Run 2)
             # Zero is passing the veto map, so Run 2 will be assigned an array of length events with all zeros
-            veto_map_array = ApplyJetVetoMaps(cleanedJets, year) if is_run3 else ak.zeros_like(met.pt)
+            veto_map_input_jets = get_veto_map_input_jets(cleanedJets, year, is_run3)
+            veto_map_array = ApplyJetVetoMaps(veto_map_input_jets, year) if is_run3 else ak.zeros_like(met.pt)
             veto_map_mask = (veto_map_array == 0)
 
             # Selecting jets and cleaning them

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -434,8 +434,8 @@ class AnalysisProcessor(processor.ProcessorABC):
                     lep_chan,
                     allow_offz_split=True,
                 )
-            if (("lt" in dense_axis_name) and ("fwd" not in lep_chan)):
-                skip_hist = True
+            # if (("lt" in dense_axis_name) and ("fwd" not in lep_chan)):
+            #     skip_hist = True
             if (("ptz_wtau" in dense_axis_name) and not self._should_fill_ptz_wtau_channel(lep_chan)):
                 skip_hist = True
         elif self._analysis_mode == "offz":

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -963,13 +963,6 @@ class AnalysisProcessor(processor.ProcessorABC):
                 cleanedJets["isTauClean"] = te_os.isClean(cleanedJets, cleaning_taus, drmin=0.5)
                 cleanedJets = cleanedJets[cleanedJets.isTauClean]
 
-            # Jet Veto Maps
-            # Removes events that have ANY jet in a specific eta-phi space (not required for Run 2)
-            # Zero is passing the veto map, so Run 2 will be assigned an array of length events with all zeros
-            veto_map_input_jets = get_veto_map_input_jets(cleanedJets, year, is_run3)
-            veto_map_array = ApplyJetVetoMaps(veto_map_input_jets, year) if is_run3 else ak.zeros_like(met.pt)
-            veto_map_mask = (veto_map_array == 0)
-
             # Selecting jets and cleaning them
             jetptname = "pt_nom" if hasattr(cleanedJets, "pt_nom") else "pt"
 
@@ -990,6 +983,14 @@ class AnalysisProcessor(processor.ProcessorABC):
                 suppress_forward_eta_stochastic_jer=effective_suppress_forward_eta_stochastic_jer,
             ).build(cleanedJets, lazy_cache=events_cache)  #Run3 ready
             cleanedJets = ApplyJetSystematics(year,cleanedJets,syst_var)
+
+            # Jet Veto Maps
+            # Removes events that have ANY jet in a specific eta-phi space (not required for Run 2)
+            # Zero is passing the veto map, so Run 2 will be assigned an array of length events with all zeros
+            veto_map_input_jets = get_veto_map_input_jets(cleanedJets, year, is_run3)
+            veto_map_array = ApplyJetVetoMaps(veto_map_input_jets, year) if is_run3 else ak.zeros_like(met.pt)
+            veto_map_mask = (veto_map_array == 0)
+
             if use_type1_met(year):
                 met = ApplyMETSystematics(type1_met, syst_var)
             else:

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -452,8 +452,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         elif self._analysis_mode == "fwd":
             if (("ptz" in dense_axis_name) and ("ptz_wtau" not in dense_axis_name)):
                 skip_hist = True
-            if (("lt" in dense_axis_name) and ("fwd" not in lep_chan)):
-                skip_hist = True
+            # if (("lt" in dense_axis_name) and ("fwd" not in lep_chan)):
+            #     skip_hist = True
         else:
             if (("ptz" in dense_axis_name) and ("ptz_wtau" not in dense_axis_name)):
                 skip_hist = not self._should_fill_plain_ptz_channel(lep_chan)

--- a/analysis/topeft_run2/fullR3_run.sh
+++ b/analysis/topeft_run2/fullR3_run.sh
@@ -306,11 +306,11 @@ main() {
     [UL18]=2018
   )
 
-  local RUN2_CFGS_SR=(
-    "${CFGS_PATH}/mc_signal_samples_NDSkim.cfg"
-    "${CFGS_PATH}/mc_background_samples_NDSkim.cfg"
-    "${CFGS_PATH}/data_samples_NDSkim.cfg"
-  )
+  # local RUN2_CFGS_SR=(
+  #   "${CFGS_PATH}/mc_signal_samples_NDSkim.cfg"
+  #   "${CFGS_PATH}/mc_background_samples_NDSkim.cfg"
+  #   "${CFGS_PATH}/data_samples_NDSkim.cfg"
+  # )
 
   local RUN2_CFGS_CR=(
     "${CFGS_PATH}/mc_signal_samples_NDSkim.cfg"
@@ -318,6 +318,12 @@ main() {
     "${CFGS_PATH}/mc_background_samples_cr_NDSkim.cfg"
     "${CFGS_PATH}/data_samples_NDSkim.cfg"
   )
+
+  # local RUN2_CFGS_CR=(
+  #   "${CFGS_PATH}/mc_signal_samples_cr_NDSkim.cfg"
+  #   "${CFGS_PATH}/mc_background_samples_cr_NDSkim.cfg"
+  #   "${CFGS_PATH}/data_samples_cr_NDSkim.cfg"
+  # )
 
   declare -A SEEN_CFGS=()
   local RUN2_BUNDLE_ADDED=false

--- a/analysis/topeft_run2/make_skim_jsons.py
+++ b/analysis/topeft_run2/make_skim_jsons.py
@@ -111,7 +111,7 @@ def main():
         last_token = tokens[-1]                                # e.g. 2022
         base = "_".join(tokens[:-1])                           # e.g. WZto3LNu-2Jets
         # produce: WZto3LNu-2Jets_NDSkim_2022.json  (since postfix already includes leading "_")
-        outname = f"{base}{postfix}_{last_token}{ext}"
+        outname = f"{base}_{last_token}{postfix}{ext}"
 
         # outname = os.path.split(matched_json_fp)[1].replace(".json",f"{postfix}.json")
         if out_dir:

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -1651,8 +1651,8 @@ if __name__ == "__main__":
             "resources_mode": "auto",
             "resource_monitor": "measure",
             "split_on_exhaustion": True,
-            'filepath': wq_staging_dir,
-            #"filepath": '/tmp',
+            #'filepath': wq_staging_dir,
+            "filepath": '/tmp',
             # this resource values may be omitted when using
             # resources_mode: 'auto', but they do make the initial portion
             # of a workflow run a little bit faster.

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -7,7 +7,7 @@ cd /users/apiccine/work/correction-lib/topeft/analysis/topeft_run2
 # Global configuration
 ###############################################################################
 
-output_dir="/groups/klannon/apiccine/photons"
+output_dir="/groups/klannon/apiccine/preappr_260613"
 chunk_size="100000"
 
 # Nominal TOP-23-002-like ttgamma sample-role strategy.
@@ -25,59 +25,114 @@ chunk_size="100000"
 ttgamma_sample_role_policy="split"
 
 # Use a strategy-specific tag to avoid mixing baseline/feature/diagnostic outputs.
-campaign_tag="rolepolicy_v2"
+campaign_tag="preappr"
 
-cr_pkl_base_tag="CR_${campaign_tag}"
-sr_pkl_base_tag="SR_${campaign_tag}"
-
-# Variables to be produced in both CR and SR pkls.
-vars=(lj0pt ptz)
-var_tag=$(IFS=-; echo "${vars[*]}")
+cr_pkl_base_tag="${campaign_tag}"
+sr_pkl_base_tag="${campaign_tag}"
 
 # Execution switches.
 #
-# Current default preserves the recent usage: produce SR pkls only.
-# Set run_cr=true when you want CR production as well.
-run_cr=false
-run_sr=true
+# This script is currently configured for Yuyi's CR distribution request.
+run_cr=true
+run_sr=false
+
+# Useful while checking resolved years/categories/histograms without launching production.
+dry_run=true
+
+# Current CR distribution production mode.
+#
+# Yuyi's request is for distributions, and the previous colleague-facing setup used
+# systematic variations for CR plotting. Keep nonprompt disabled unless explicitly needed.
+do_systs=true
+do_np=false
+
+# Enable only if the colleague explicitly needs lepton-flavour split outputs.
+split_lep_flavor=false
+
+###############################################################################
+# Histogram variable chunks
+###############################################################################
+
+# Each entry is one independent histogram chunk.
+#
+# Important:
+#   These are intentionally strings. Each string is split into a real bash array
+#   inside run_cr_block/run_sr_block before passing --hist-vars to fullR3_run.sh.
+#
+# Requested coverage:
+#   - fwd0pt for all periods/regions;
+#   - fwd0eta, lj0pt, lt, met, ptz for the relevant non-tau CRs;
+#   - ptz_wtau and tau variables for tau CR coverage;
+#   - invmass, j0eta, j0pt, l0/l1 variables, ljptsum, nbtagsl, njets for tau CRs.
+var_sets=(
+  "fwd0pt fwd0eta lj0pt lt"
+  "met ptz njets nbtagsl"
+  "l0conept l0eta l1conept l1eta"
+  "j0pt j0eta invmass ljptsum"
+  "j1pt j1eta nbtagsm npvsGood"
+  # "ptz_wtau tau0Fpt tau0Tpt"
+)
 
 ###############################################################################
 # CR configuration
 ###############################################################################
 
-# Each entry is one independent year expression passed to fullR3_run.sh.
-# Examples:
-#   cr_year_sets=(2022EE 2018)        # two separate runs
-#   cr_year_sets=("2022EE 2018")      # one combined run
+# Keep year periods separate so the output pkls are period-specific.
+#
+# Yuyi requested Run 2 period-specific coverage and Run 3 tau-region coverage.
 cr_year_sets=(
-  "2022EE 2018"
+  2016APV
+  2016
+  2017
+  2018
+  2022
+  2022EE
+  2023
+  2023BPix
 )
 
-# Each entry is one independent subset of categories.
-# The script will run all subsets for every year expression.
+# Current category names used by the analysis helpers.
+#
+# Mapping to Yuyi labels:
+#   2los_Z      -> 2los_CRZ
+#   2lss_flip   -> 2l_CRflip
+#   2los_tt     -> 2los_CRtt
+#   3l          -> 3l_CR
+#   dy_tautau   -> 1l_1tau_CRDY
+#   1l_1tau_tt  -> 1l_1tau_CRtt
+#
+# The aggregate 2los_1tau group is included for the 2los tau request.
+# If the branch has explicit 2los_1tau_Ftau / 2los_1tau_Ttau category groups,
+# they can be added as separate entries after confirming the exact names.
 cr_category_sets=(
+  "2los_CRZ"
+  "2l_CRflip"
   "2los_CRtt"
-  # "2l_CR 2los_CRtt 3l_CR"
-  # "2los_CRZ 2l_CRflip"
-  # "2los_1tau 1l_1tau_CRtt 1l_1tau_CRDY"
+  "2l_CR"
+  "3l_CR"
+  # "1l_1tau_CRtt"
+  # "1l_1tau_CRDY"
+  # "2los_1tau"
+  # "2los_1tau_Ftau"
+  # "2los_1tau_Ttau"
 )
 
 ###############################################################################
 # SR configuration
 ###############################################################################
 
-# Each entry is one independent year expression passed to fullR3_run.sh.
-# Examples:
-#   sr_year_sets=(2022 2022EE 2023 2023BPix)              # separate runs
-#   sr_year_sets=("2022 2022EE 2023 2023BPix")            # one combined run
+# Kept available, but disabled by default for this request.
 sr_year_sets=(
+  2022
   2022EE
+  2023
+  2023BPix
+  2016APV
+  2016
+  2017
   2018
-  # "2022 2022EE 2023 2023BPix"
 )
 
-# Each entry is one independent subset of categories.
-# Grouped entries produce one pkl per grouped set.
 sr_category_sets=(
   "2l 2lss_1tau 2los_1tau 3l_m_offZ"
   "3l_p_offZ 3l_onZ_tau 3l_fwd 4l"
@@ -93,6 +148,16 @@ join_by() {
 
   local IFS="$delimiter"
   echo "$*"
+}
+
+bool_to_option_enabled() {
+  case "$1" in
+    true|false) ;;
+    *)
+      echo "ERROR: expected boolean true/false, got '$1'" >&2
+      exit 1
+      ;;
+  esac
 }
 
 clean_env_cache() {
@@ -132,30 +197,76 @@ print_command() {
   echo
 }
 
+print_var_sets() {
+  local var_set
+  local index=0
+
+  for var_set in "${var_sets[@]}"; do
+    index=$((index + 1))
+    echo "  ${index}: ${var_set}"
+  done
+}
+
+build_common_command_options() {
+  local -n cmd_ref="$1"
+
+  cmd_ref+=(--ttgamma-sample-role-policy "${ttgamma_sample_role_policy}")
+
+  if [[ "${do_systs}" == "true" ]]; then
+    cmd_ref+=(--do-systs)
+  fi
+
+  if [[ "${do_np}" == "true" ]]; then
+    cmd_ref+=(--do-np)
+  fi
+
+  cmd_ref+=(
+    -p "${output_dir}"
+    --suppress-forward-eta-stochastic-jer
+    --all-analysis
+  )
+
+  if [[ "${split_lep_flavor}" == "true" ]]; then
+    cmd_ref+=(--split-lep-flavor)
+  fi
+
+  if [[ "${dry_run}" == "true" ]]; then
+    cmd_ref+=(--dry-run)
+  fi
+}
+
 run_cr_block() {
   local year_expr="$1"
-  shift
+  local var_set="$2"
+  shift 2
 
   assert_supported_year_expr "${year_expr}"
 
   local years=()
   read -r -a years <<< "${year_expr}"
 
+  local vars=()
+  read -r -a vars <<< "${var_set}"
+
   local cats=("$@")
   local cat_tag
+  local var_tag
   local pkl_tag
 
   cat_tag=$(join_by - "${cats[@]}")
+  var_tag=$(join_by - "${vars[@]}")
   pkl_tag="${cr_pkl_base_tag}_${cat_tag}_${var_tag}"
 
   echo "----------------------------------------"
   echo "Mode: CR"
   echo "Years: ${year_expr}"
   echo "Categories: ${cats[*]}"
+  echo "Variables: ${vars[*]}"
   echo "ttgamma sample-role policy: ${ttgamma_sample_role_policy}"
   echo "Campaign tag: ${campaign_tag}"
   echo "Output tag: ${pkl_tag}"
   echo "Output dir: ${output_dir}"
+  echo "Dry run: ${dry_run}"
   echo "----------------------------------------"
 
   clean_env_cache
@@ -167,48 +278,51 @@ run_cr_block() {
     -s "${chunk_size}"
     --cr
     --hist-vars "${vars[@]}"
-    --ttgamma-sample-role-policy "${ttgamma_sample_role_policy}"
-    # --do-systs
-    --do-np
-    -p "${output_dir}"
     --category-groups "${cats[@]}"
-    --suppress-forward-eta-stochastic-jer
-    --all-analysis
-    # --split-lep-flavor
   )
+
+  build_common_command_options cmd
 
   print_command "${cmd[@]}"
   "${cmd[@]}"
 
-  echo "${year_expr} CR done"
+  echo "${year_expr} CR done for ${cat_tag} / ${var_tag}"
   echo "----------------------------------------"
   echo
 }
 
 run_sr_block() {
   local year_expr="$1"
-  shift
+  local var_set="$2"
+  shift 2
 
   assert_supported_year_expr "${year_expr}"
 
   local years=()
   read -r -a years <<< "${year_expr}"
 
+  local vars=()
+  read -r -a vars <<< "${var_set}"
+
   local cats=("$@")
   local cat_tag
+  local var_tag
   local pkl_tag
 
   cat_tag=$(join_by - "${cats[@]}")
+  var_tag=$(join_by - "${vars[@]}")
   pkl_tag="${sr_pkl_base_tag}_${cat_tag}_${var_tag}"
 
   echo "----------------------------------------"
   echo "Mode: SR"
   echo "Years: ${year_expr}"
   echo "Categories: ${cats[*]}"
+  echo "Variables: ${vars[*]}"
   echo "ttgamma sample-role policy: ${ttgamma_sample_role_policy}"
   echo "Campaign tag: ${campaign_tag}"
   echo "Output tag: ${pkl_tag}"
   echo "Output dir: ${output_dir}"
+  echo "Dry run: ${dry_run}"
   echo "----------------------------------------"
 
   clean_env_cache
@@ -220,20 +334,15 @@ run_sr_block() {
     -s "${chunk_size}"
     --sr
     --hist-vars "${vars[@]}"
-    --ttgamma-sample-role-policy "${ttgamma_sample_role_policy}"
-    # --do-systs
-    --do-np
-    -p "${output_dir}"
     --category-groups "${cats[@]}"
-    --suppress-forward-eta-stochastic-jer
-    --all-analysis
-    # --split-lep-flavor
   )
+
+  build_common_command_options cmd
 
   print_command "${cmd[@]}"
   "${cmd[@]}"
 
-  echo "${year_expr} SR done"
+  echo "${year_expr} SR done for ${cat_tag} / ${var_tag}"
   echo "----------------------------------------"
   echo
 }
@@ -242,15 +351,27 @@ run_sr_block() {
 # Preflight summary
 ###############################################################################
 
+bool_to_option_enabled "${run_cr}"
+bool_to_option_enabled "${run_sr}"
+bool_to_option_enabled "${dry_run}"
+bool_to_option_enabled "${do_systs}"
+bool_to_option_enabled "${do_np}"
+bool_to_option_enabled "${split_lep_flavor}"
+
 echo "========================================"
 echo "run_cr.sh configuration"
 echo "campaign_tag: ${campaign_tag}"
 echo "ttgamma sample-role policy: ${ttgamma_sample_role_policy}"
 echo "output_dir: ${output_dir}"
 echo "chunk_size: ${chunk_size}"
-echo "vars: ${vars[*]}"
 echo "run_cr: ${run_cr}"
 echo "run_sr: ${run_sr}"
+echo "dry_run: ${dry_run}"
+echo "do_systs: ${do_systs}"
+echo "do_np: ${do_np}"
+echo "split_lep_flavor: ${split_lep_flavor}"
+echo "variable chunks:"
+print_var_sets
 echo "========================================"
 echo
 
@@ -278,7 +399,10 @@ if [[ "${run_cr}" == "true" ]]; then
   for year_expr in "${cr_year_sets[@]}"; do
     for category_set in "${cr_category_sets[@]}"; do
       read -r -a cats <<< "${category_set}"
-      run_cr_block "${year_expr}" "${cats[@]}"
+
+      for var_set in "${var_sets[@]}"; do
+        run_cr_block "${year_expr}" "${var_set}" "${cats[@]}"
+      done
     done
   done
 else
@@ -294,7 +418,10 @@ if [[ "${run_sr}" == "true" ]]; then
   for year_expr in "${sr_year_sets[@]}"; do
     for category_set in "${sr_category_sets[@]}"; do
       read -r -a cats <<< "${category_set}"
-      run_sr_block "${year_expr}" "${cats[@]}"
+
+      for var_set in "${var_sets[@]}"; do
+        run_sr_block "${year_expr}" "${var_set}" "${cats[@]}"
+      done
     done
   done
 else

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -8,7 +8,7 @@ cd /users/apiccine/work/correction-lib/topeft/analysis/topeft_run2
 ###############################################################################
 
 output_dir="/groups/klannon/apiccine/preappr_260613"
-chunk_size="100000"
+chunk_size="50000"
 
 # Nominal TOP-23-002-like ttgamma sample-role strategy.
 #
@@ -102,10 +102,8 @@ cr_year_sets=(
 # If the branch has explicit 2los_1tau_Ftau / 2los_1tau_Ttau category groups,
 # they can be added as separate entries after confirming the exact names.
 cr_category_sets=(
-  "2los_CRZ"
-  "2l_CRflip"
-  "2los_CRtt"
-  "2l_CR"
+  "2los_CRZ 2l_CRflip"
+  "2los_CRtt 2l_CR"
   "3l_CR"
   # "1l_1tau_CRtt"
   # "1l_1tau_CRDY"

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -7,7 +7,7 @@ cd /users/apiccine/work/correction-lib/topeft/analysis/topeft_run2
 # Global configuration
 ###############################################################################
 
-output_dir="/groups/klannon/apiccine/preappr_260613"
+output_dir="/groups/klannon/apiccine/preappr_1l1tau_260613"
 chunk_size="50000"
 
 # Nominal TOP-23-002-like ttgamma sample-role strategy.
@@ -44,7 +44,7 @@ dry_run=false
 # Yuyi's request is for distributions, and the previous colleague-facing setup used
 # systematic variations for CR plotting. Keep nonprompt disabled unless explicitly needed.
 do_systs=true
-do_np=true
+do_np=false
 
 # Enable only if the colleague explicitly needs lepton-flavour split outputs.
 split_lep_flavor=false
@@ -65,9 +65,11 @@ split_lep_flavor=false
 #   - ptz_wtau and tau variables for tau CR coverage;
 #   - invmass, j0eta, j0pt, l0/l1 variables, ljptsum, nbtagsl, njets for tau CRs.
 var_sets=(
-  "fwd0pt fwd0eta lj0pt lt met ptz nbtagsl l0conept l0eta"
-  "njets l1conept l1eta j0pt j0eta invmass ljptsum nbtagsm npvsGood"
-  # "ptz_wtau tau0Fpt tau0Tpt"
+  # "fwd0pt fwd0eta lj0pt lt met ptz nbtagsl l0conept l0eta"
+  # "njets l1conept l1eta j0pt j0eta invmass ljptsum nbtagsm npvsGood"
+  # "l0eta l0conept met lt njets ptz_wtau tau0Fpt tau0Tpt"
+  # "lt"
+  "lj0pt nbtagsl nbtagsm fwd0pt fwd0eta lt"
 )
 
 ###############################################################################
@@ -78,12 +80,12 @@ var_sets=(
 #
 # Yuyi requested Run 2 period-specific coverage and Run 3 tau-region coverage.
 cr_year_sets=(
-  2016APV
-  2016
-  2017
-  2018
-  2022
-  2022EE
+  # 2016APV
+  # 2016
+  # 2017
+  # 2018
+  # 2022
+  # 2022EE
   2023
   2023BPix
 )
@@ -102,14 +104,8 @@ cr_year_sets=(
 # If the branch has explicit 2los_1tau_Ftau / 2los_1tau_Ttau category groups,
 # they can be added as separate entries after confirming the exact names.
 cr_category_sets=(
-  "2los_CRZ 2l_CRflip"
-  "2los_CRtt 2l_CR"
-  "3l_CR"
-  # "1l_1tau_CRtt"
-  # "1l_1tau_CRDY"
-  # "2los_1tau"
-  # "2los_1tau_Ftau"
-  # "2los_1tau_Ttau"
+  # "2los_CRZ 2l_CR 2los_CRtt 2l_CRflip 3l_CR"
+  "1l_1tau_CRtt 1l_1tau_CRDY 2los_1tau"
 )
 
 ###############################################################################

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -37,14 +37,14 @@ run_cr=true
 run_sr=false
 
 # Useful while checking resolved years/categories/histograms without launching production.
-dry_run=true
+dry_run=false
 
 # Current CR distribution production mode.
 #
 # Yuyi's request is for distributions, and the previous colleague-facing setup used
 # systematic variations for CR plotting. Keep nonprompt disabled unless explicitly needed.
 do_systs=true
-do_np=false
+do_np=true
 
 # Enable only if the colleague explicitly needs lepton-flavour split outputs.
 split_lep_flavor=false
@@ -65,11 +65,8 @@ split_lep_flavor=false
 #   - ptz_wtau and tau variables for tau CR coverage;
 #   - invmass, j0eta, j0pt, l0/l1 variables, ljptsum, nbtagsl, njets for tau CRs.
 var_sets=(
-  "fwd0pt fwd0eta lj0pt lt"
-  "met ptz njets nbtagsl"
-  "l0conept l0eta l1conept l1eta"
-  "j0pt j0eta invmass ljptsum"
-  "j1pt j1eta nbtagsm npvsGood"
+  "fwd0pt fwd0eta lj0pt lt met ptz nbtagsl l0conept l0eta"
+  "njets l1conept l1eta j0pt j0eta invmass ljptsum nbtagsm npvsGood"
   # "ptz_wtau tau0Fpt tau0Tpt"
 )
 

--- a/input_samples/cfgs/NDSkim_2022EE_background_samples.cfg
+++ b/input_samples/cfgs/NDSkim_2022EE_background_samples.cfg
@@ -13,6 +13,7 @@ root://cmsxrootd.crc.nd.edu/
 ../../input_samples/sample_jsons/background_samples/ND_skim2022EE/TTG-1Jets_PTG-200_NDSkim_2022EE.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022EE/TTto2L2Nu_NDSkim_2022EE.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022EE/TTtoLNu2Q_NDSkim_2022EE.json
+../../input_samples/sample_jsons/background_samples/ND_skim2022EE/TWZ_Tto2Q_WtoLNu_Zto2L_NDSkim_2022EE.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022EE/TWZ_TtoLNu_Wto2Q_Zto2L_NDSkim_2022EE.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022EE/TWZ_TtoLNu_WtoLNu_Zto2L_NDSkim_2022EE.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022EE/WWTo2L2Nu_NDSkim_2022EE.json

--- a/input_samples/cfgs/NDSkim_2022_background_samples.cfg
+++ b/input_samples/cfgs/NDSkim_2022_background_samples.cfg
@@ -13,6 +13,7 @@ root://cmsxrootd.crc.nd.edu/
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/TTG-1Jets_PTG-200_NDSkim_2022.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/TTto2L2Nu_NDSkim_2022.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/TTtoLNu2Q_NDSkim_2022.json
+../../input_samples/sample_jsons/background_samples/ND_skim2022/TWZ_Tto2Q_WtoLNu_Zto2L_NDSkim_2022.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/TWZ_TtoLNu_Wto2Q_Zto2L_NDSkim_2022.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/TWZ_TtoLNu_WtoLNu_Zto2L_NDSkim_2022.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/WWTo2L2Nu_NDSkim_2022.json

--- a/input_samples/cfgs/NDSkim_2022_background_samples_cr.cfg
+++ b/input_samples/cfgs/NDSkim_2022_background_samples_cr.cfg
@@ -2,8 +2,6 @@ root://cmsxrootd.crc.nd.edu/
 #file:///cms/cephfs/data/
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/DYJetsToLL_MLL-10to50_fixed_NDSkim_2022.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/DYJetsToLL_MLL-50_fixed_NDSkim_2022.json
-# ../../input_samples/sample_jsons/background_samples/ND_skim2022/DYJetsToLL_MLL-10to50_NDSkim_2022.json
-# ../../input_samples/sample_jsons/background_samples/ND_skim2022/DYJetsToLL_MLL-50_NDSkim_2022.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/ggToZZTo2e2mu_NDSkim_2022.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/ggToZZTo2e2nu_NDSkim_2022.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/ggToZZTo2mu2nu_NDSkim_2022.json
@@ -22,6 +20,9 @@ root://cmsxrootd.crc.nd.edu/
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/TTG-1Jets_PTG-100to200_NDSkim_2022.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/TTG-1Jets_PTG-10to100_NDSkim_2022.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/TTG-1Jets_PTG-200_NDSkim_2022.json
+../../input_samples/sample_jsons/background_samples/ND_skim2022/TWZ_Tto2Q_WtoLNu_Zto2L_NDSkim_2022.json
+../../input_samples/sample_jsons/background_samples/ND_skim2022/TWZ_TtoLNu_Wto2Q_Zto2L_NDSkim_2022.json
+../../input_samples/sample_jsons/background_samples/ND_skim2022/TWZ_TtoLNu_WtoLNu_Zto2L_NDSkim_2022.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/TTto2L2Nu_NDSkim_2022.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/TTto4Q_NDSkim_2022.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2022/TTtoLNu2Q_NDSkim_2022.json

--- a/input_samples/cfgs/NDSkim_2023BPix_background_samples.cfg
+++ b/input_samples/cfgs/NDSkim_2023BPix_background_samples.cfg
@@ -13,6 +13,7 @@ root://cmsxrootd.crc.nd.edu/
 ../../input_samples/sample_jsons/background_samples/ND_skim2023BPix/TTG-1Jets_PTG-200_NDSkim_2023BPix.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2023BPix/TTto2L2Nu_NDSkim_2023BPix.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2023BPix/TTtoLNu2Q_NDSkim_2023BPix.json
+../../input_samples/sample_jsons/background_samples/ND_skim2023BPix/TWZ_Tto2Q_WtoLNu_Zto2L_NDSkim_2023BPix.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2023BPix/TWZ_TtoLNu_Wto2Q_Zto2L_NDSkim_2023BPix.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2023BPix/TWZ_TtoLNu_WtoLNu_Zto2L_NDSkim_2023BPix.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2023BPix/WWTo2L2Nu_NDSkim_2023BPix.json

--- a/input_samples/cfgs/NDSkim_2023_background_samples.cfg
+++ b/input_samples/cfgs/NDSkim_2023_background_samples.cfg
@@ -13,6 +13,7 @@ root://cmsxrootd.crc.nd.edu/
 ../../input_samples/sample_jsons/background_samples/ND_skim2023/TTG-1Jets_PTG-200_NDSkim_2023.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2023/TTto2L2Nu_NDSkim_2023.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2023/TTtoLNu2Q_NDSkim_2023.json
+../../input_samples/sample_jsons/background_samples/ND_skim2023/TWZ_Tto2Q_WtoLNu_Zto2L_NDSkim_2023.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2023/TWZ_TtoLNu_Wto2Q_Zto2L_NDSkim_2023.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2023/TWZ_TtoLNu_WtoLNu_Zto2L_NDSkim_2023.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2023/WWTo2L2Nu_NDSkim_2023.json

--- a/input_samples/cfgs/NDSkim_2023_background_samples_cr.cfg
+++ b/input_samples/cfgs/NDSkim_2023_background_samples_cr.cfg
@@ -2,8 +2,6 @@ root://cmsxrootd.crc.nd.edu/
 #file:///cms/cephfs/data/
 ../../input_samples/sample_jsons/background_samples/ND_skim2023/DYJetsToLL_MLL-10to50_fixed_NDSkim_2023.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2023/DYJetsToLL_MLL-50_fixed_NDSkim_2023.json
-# ../../input_samples/sample_jsons/background_samples/ND_skim2023/DYJetsToLL_MLL-10to50_NDSkim_2023.json
-# ../../input_samples/sample_jsons/background_samples/ND_skim2023/DYJetsToLL_MLL-50_NDSkim_2023.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2023/ggToZZTo2e2mu_NDSkim_2023.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2023/ggToZZTo2e2tau_NDSkim_2023.json
 ../../input_samples/sample_jsons/background_samples/ND_skim2023/ggToZZTo2e2nu_NDSkim_2023.json

--- a/input_samples/cfgs/mc_background_samples_cr_NDSkim.cfg
+++ b/input_samples/cfgs/mc_background_samples_cr_NDSkim.cfg
@@ -1,4 +1,4 @@
-# Central background samples (just relevant for CRs)
+# # Central background samples (just relevant for CRs)
 
 # Central UL16APV background samples
 root://cmsxrootd.crc.nd.edu/
@@ -15,32 +15,32 @@ root://cmsxrootd.crc.nd.edu/
 ../../input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL16APV_NDSkim_2016APV.json
 
 # # Central UL16 background samples
-# root://cmsxrootd.crc.nd.edu/
-# #file:///cms/cephfs/data/
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_ZGToLLG_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_DY10to50_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_DY50_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_antitop_t-channel_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_top_s-channel_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_top_t-channel_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_tbarW_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_tW_NDSkim.json
-# # ../../input_samples/sample_jsons/background_samples/central_UL/UL16_WJetsToLNu_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL16_NDSkim_2016.json
+root://cmsxrootd.crc.nd.edu/
+#file:///cms/cephfs/data/
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_ZGToLLG_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_DY10to50_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_DY50_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_antitop_t-channel_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_top_s-channel_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_top_t-channel_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_tbarW_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_tW_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_WJetsToLNu_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL16_NDSkim_2016.json
 
 # # Central UL17 background samples
-# root://cmsxrootd.crc.nd.edu/
-# #file:///cms/cephfs/data/
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_ZGToLLG_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_DY10to50_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_DY50_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_antitop_t-channel_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_top_s-channel_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_top_t-channel_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_tbarW_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_tW_NDSkim.json
-# # ../../input_samples/sample_jsons/background_samples/central_UL/UL17_WJetsToLNu_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL17_NDSkim_2017.json
+root://cmsxrootd.crc.nd.edu/
+#file:///cms/cephfs/data/
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_ZGToLLG_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_DY10to50_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_DY50_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_antitop_t-channel_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_top_s-channel_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_top_t-channel_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_tbarW_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_tW_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_WJetsToLNu_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL17_NDSkim_2017.json
 
 # # Central UL18 background samples
 root://cmsxrootd.crc.nd.edu/
@@ -55,3 +55,152 @@ root://cmsxrootd.crc.nd.edu/
 ../../input_samples/sample_jsons/background_samples/central_UL/UL18_tW_NDSkim.json
 # ../../input_samples/sample_jsons/background_samples/central_UL/UL18_WJetsToLNu_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL18_NDSkim_2018.json
+
+
+
+
+# # Central background samples (just relevant for CRs)
+
+# # Central UL16APV background samples
+# root://cmsxrootd.crc.nd.edu/
+# #file:///cms/cephfs/data/
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_ZGToLLG_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_DY10to50_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_DY50_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_ST_antitop_t-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_ST_top_s-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_ST_top_t-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_tbarW_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_tW_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/WJetsToLNu_centralUL16APV_NDSkim_2016APV.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_TWZToLL_thad_Wlept_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_TWZToLL_tlept_Whad_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_TWZToLL_tlept_Wlept_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_TTGJets_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_TTGamma_Dilept_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_TTGamma_SingleLept_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_WWTo2L2Nu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_WWW_4F_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_WWZ_4F_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_WZTo3LNu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_WZZ_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_ZZTo4L_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_ZZZ_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_TTZToLL_M-1to10_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_TTTo2L2Nu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_TTToSemiLeptonic_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_GluGluToContinToZZTo2e2mu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_GluGluToContinToZZTo2e2nu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_GluGluToContinToZZTo2e2tau_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_GluGluToContinToZZTo2mu2tau_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_GluGluToContinToZZTo4e_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_GluGluToContinToZZTo4mu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16APV_GluGluToContinToZZTo4tau_NDSkim.json
+
+# # # Central UL16 background samples
+# root://cmsxrootd.crc.nd.edu/
+# #file:///cms/cephfs/data/
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_ZGToLLG_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_DY10to50_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_DY50_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_ST_antitop_t-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_ST_top_s-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_ST_top_t-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_tbarW_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_tW_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/WJetsToLNu_centralUL16_NDSkim_2016.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_TWZToLL_thad_Wlept_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_TWZToLL_tlept_Whad_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_TWZToLL_tlept_Wlept_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_TTGJets_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_TTGamma_Dilept_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_TTGamma_SingleLept_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_WWTo2L2Nu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_WWW_4F_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_WWZ_4F_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_WZTo3LNu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_WZZ_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_ZZTo4L_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_ZZZ_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_TTZToLL_M-1to10_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_TTTo2L2Nu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_TTToSemiLeptonic_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_GluGluToContinToZZTo2e2mu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_GluGluToContinToZZTo2e2nu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_GluGluToContinToZZTo2e2tau_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_GluGluToContinToZZTo2mu2tau_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_GluGluToContinToZZTo4e_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_GluGluToContinToZZTo4mu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL16_GluGluToContinToZZTo4tau_NDSkim.json
+
+# # # Central UL17 background samples
+# root://cmsxrootd.crc.nd.edu/
+# #file:///cms/cephfs/data/
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_ZGToLLG_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_DY10to50_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_DY50_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_ST_antitop_t-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_ST_top_s-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_ST_top_t-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_tbarW_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_tW_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/WJetsToLNu_centralUL17_NDSkim_2017.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_TWZToLL_thad_Wlept_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_TWZToLL_tlept_Whad_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_TWZToLL_tlept_Wlept_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_TTGJets_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_TTGamma_Dilept_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_TTGamma_SingleLept_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_WWTo2L2Nu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_WWW_4F_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_WWZ_4F_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_WZTo3LNu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_WZZ_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_ZZTo4L_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_ZZZ_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_TTZToLL_M-1to10_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_TTTo2L2Nu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_TTToSemiLeptonic_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_GluGluToContinToZZTo2e2mu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_GluGluToContinToZZTo2e2nu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_GluGluToContinToZZTo2e2tau_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_GluGluToContinToZZTo2mu2tau_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_GluGluToContinToZZTo4e_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_GluGluToContinToZZTo4mu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL17_GluGluToContinToZZTo4tau_NDSkim.json
+
+# # # Central UL18 background samples
+# root://cmsxrootd.crc.nd.edu/
+# #file:///cms/cephfs/data/
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_ZGToLLG_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_DY10to50_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_DY50_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_ST_antitop_t-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_ST_top_s-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_ST_top_t-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_tbarW_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_tW_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/WJetsToLNu_centralUL18_NDSkim_2018.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_TWZToLL_thad_Wlept_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_TWZToLL_tlept_Whad_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_TWZToLL_tlept_Wlept_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_TTGJets_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_TTGamma_Dilept_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_TTGamma_SingleLept_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_WWTo2L2Nu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_WWW_4F_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_WWZ_4F_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_WZTo3LNu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_WZZ_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_ZZTo4L_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_ZZZ_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_TTZToLL_M-1to10_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_TTTo2L2Nu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_TTToSemiLeptonic_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_GluGluToContinToZZTo2e2mu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_GluGluToContinToZZTo2e2nu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_GluGluToContinToZZTo2e2tau_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_GluGluToContinToZZTo2mu2tau_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_GluGluToContinToZZTo4e_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_GluGluToContinToZZTo4mu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL_cr/UL18_GluGluToContinToZZTo4tau_NDSkim.json

--- a/tests/test_met_collection_policy.py
+++ b/tests/test_met_collection_policy.py
@@ -123,15 +123,33 @@ def test_run2_type1_data_jec_levels_include_residuals(year, era):
 
 
 @pytest.mark.parametrize("year", ["2016APV", "2016", "2017", "2018"])
-def test_regular_run2_analysis_jet_jec_levels_are_unchanged(year):
+def test_regular_run2_mc_analysis_jet_jec_levels_use_full_l1l2l3(year):
     _, _, levels, _, _ = get_jerc_keys(year, isdata=False, corr_type="jets")
 
-    assert levels == ["L1FastJet", "L2Relative"]
+    assert levels == ["L1FastJet", "L2Relative", "L3Absolute"]
+
+
+@pytest.mark.parametrize(
+    ("year", "era"),
+    [("2016APV", "B"), ("2016", "F"), ("2017", "B"), ("2018", "A")],
+)
+def test_regular_run2_data_analysis_jet_jec_levels_include_residuals(year, era):
+    _, _, levels, _, _ = get_jerc_keys(year, isdata=True, era=era, corr_type="jets")
+
+    assert levels == ["L1FastJet", "L2Relative", "L3Absolute", "L2L3Residual"]
 
 
 def test_run3_type1_jec_levels_are_unchanged():
     _, _, mc_levels, _, _ = get_jerc_keys("2022", isdata=False, corr_type="type1_met")
     _, _, data_levels, _, _ = get_jerc_keys("2022", isdata=True, era="C", corr_type="type1_met")
+
+    assert mc_levels == ["L1FastJet", "L2Relative", "L3Absolute", "L2L3Residual"]
+    assert data_levels == ["L1FastJet", "L2Relative", "L3Absolute", "L2L3Residual"]
+
+
+def test_run3_regular_jet_jec_levels_are_unchanged():
+    _, _, mc_levels, _, _ = get_jerc_keys("2022", isdata=False, corr_type="jets")
+    _, _, data_levels, _, _ = get_jerc_keys("2022", isdata=True, era="C", corr_type="jets")
 
     assert mc_levels == ["L1FastJet", "L2Relative", "L3Absolute", "L2L3Residual"]
     assert data_levels == ["L1FastJet", "L2Relative", "L3Absolute", "L2L3Residual"]

--- a/tests/test_run3_veto_map_input_selection.py
+++ b/tests/test_run3_veto_map_input_selection.py
@@ -1,6 +1,16 @@
 import awkward as ak
+from pathlib import Path
 
 from analysis.topeft_run2.analysis_processor import get_veto_map_input_jets
+
+
+def _processor_source():
+    return (
+        Path(__file__).parents[1]
+        / "analysis"
+        / "topeft_run2"
+        / "analysis_processor.py"
+    ).read_text()
 
 
 def test_get_veto_map_input_jets_applies_run3_minimal_selection():
@@ -76,9 +86,103 @@ def test_get_veto_map_input_jets_applies_run3_minimal_selection():
     assert ak.to_list(selected.pt) == [[20.0, 80.0]]
 
 
+def test_get_veto_map_input_jets_uses_received_pt_field():
+    jets = ak.Array(
+        [
+            [
+                {
+                    "pt": 16.0,
+                    "pt_raw": 10.0,
+                    "eta": 0.2,
+                    "jetId": 2,
+                    "chHEF": 0.5,
+                    "neHEF": 0.1,
+                    "neEmEF": 0.1,
+                    "muEF": 0.1,
+                    "chEmEF": 0.1,
+                },
+                {
+                    "pt": 14.0,
+                    "pt_raw": 30.0,
+                    "eta": 0.2,
+                    "jetId": 2,
+                    "chHEF": 0.5,
+                    "neHEF": 0.1,
+                    "neEmEF": 0.1,
+                    "muEF": 0.1,
+                    "chEmEF": 0.1,
+                },
+            ]
+        ]
+    )
+
+    selected = get_veto_map_input_jets(jets, "2022", True)
+
+    assert ak.to_list(selected.pt) == [[16.0]]
+    assert ak.to_list(selected.pt_raw) == [[10.0]]
+
+
+def test_get_veto_map_input_jets_keeps_jme_selection_looser_than_analysis_jets():
+    jets = ak.Array(
+        [
+            [
+                {
+                    "pt": 16.0,
+                    "eta": 0.2,
+                    "jetId": 2,
+                    "chHEF": 0.5,
+                    "neHEF": 0.1,
+                    "neEmEF": 0.1,
+                    "muEF": 0.1,
+                    "chEmEF": 0.1,
+                }
+            ]
+        ]
+    )
+
+    selected = get_veto_map_input_jets(jets, "2022", True)
+
+    assert ak.to_list(selected.pt) == [[16.0]]
+
+
 def test_get_veto_map_input_jets_preserves_non_run3_inputs():
     jets = ak.Array([[{"pt": 10.0}, {"pt": 20.0}]])
 
     selected = get_veto_map_input_jets(jets, "2018", False)
 
     assert ak.to_list(selected.pt) == [[10.0, 20.0]]
+
+
+def test_processor_applies_run3_veto_maps_after_jet_corrections_and_systematics():
+    source = _processor_source()
+
+    cleaning = source.index("cleanedJets = jets[~ak.any(tmp.slot0 == tmp.slot1, axis=-1)]")
+    raw_attachment = source.index('cleanedJets["pt_raw"] =')
+    corrections = source.index("cleanedJets = ApplyJetCorrections(")
+    systematics = source.index("cleanedJets = ApplyJetSystematics(year,cleanedJets,syst_var)")
+    veto_inputs = source.index(
+        "veto_map_input_jets = get_veto_map_input_jets(cleanedJets, year, is_run3)"
+    )
+    veto_eval = source.index(
+        "veto_map_array = ApplyJetVetoMaps(veto_map_input_jets, year) if is_run3 else ak.zeros_like(met.pt)"
+    )
+    analysis_jet_selection = source.index('cleanedJets["isGood"]')
+
+    assert (
+        cleaning
+        < raw_attachment
+        < corrections
+        < systematics
+        < veto_inputs
+        < veto_eval
+        < analysis_jet_selection
+    )
+
+
+def test_processor_keeps_run2_veto_maps_disabled():
+    source = _processor_source()
+
+    assert (
+        "veto_map_array = ApplyJetVetoMaps(veto_map_input_jets, year) if is_run3 else ak.zeros_like(met.pt)"
+        in source
+    )

--- a/tests/test_run3_veto_map_input_selection.py
+++ b/tests/test_run3_veto_map_input_selection.py
@@ -1,0 +1,84 @@
+import awkward as ak
+
+from analysis.topeft_run2.analysis_processor import get_veto_map_input_jets
+
+
+def test_get_veto_map_input_jets_applies_run3_minimal_selection():
+    jets = ak.Array(
+        [
+            [
+                {
+                    "pt": 20.0,
+                    "eta": 0.2,
+                    "jetId": 2,
+                    "chHEF": 0.5,
+                    "neHEF": 0.1,
+                    "neEmEF": 0.1,
+                    "muEF": 0.1,
+                    "chEmEF": 0.1,
+                },
+                {
+                    "pt": 15.0,
+                    "eta": 0.2,
+                    "jetId": 2,
+                    "chHEF": 0.5,
+                    "neHEF": 0.1,
+                    "neEmEF": 0.1,
+                    "muEF": 0.1,
+                    "chEmEF": 0.1,
+                },
+                {
+                    "pt": 30.0,
+                    "eta": 0.2,
+                    "jetId": 0,
+                    "chHEF": 0.5,
+                    "neHEF": 0.1,
+                    "neEmEF": 0.1,
+                    "muEF": 0.1,
+                    "chEmEF": 0.1,
+                },
+                {
+                    "pt": 40.0,
+                    "eta": 0.2,
+                    "jetId": 2,
+                    "chHEF": 0.5,
+                    "neHEF": 0.1,
+                    "neEmEF": 0.35,
+                    "muEF": 0.1,
+                    "chEmEF": 0.6,
+                },
+                {
+                    "pt": 50.0,
+                    "eta": 0.2,
+                    "jetId": 2,
+                    "chHEF": 0.5,
+                    "neHEF": 0.1,
+                    "neEmEF": 0.02,
+                    "muEF": 0.1,
+                    "chEmEF": 0.85,
+                },
+                {
+                    "pt": 80.0,
+                    "eta": 3.2,
+                    "jetId": 2,
+                    "chHEF": 0.5,
+                    "neHEF": 0.1,
+                    "neEmEF": 0.1,
+                    "muEF": 0.9,
+                    "chEmEF": 0.0,
+                },
+            ]
+        ]
+    )
+
+    selected = get_veto_map_input_jets(jets, "2022", True)
+
+    assert ak.to_list(selected.pt) == [[20.0, 80.0]]
+
+
+def test_get_veto_map_input_jets_preserves_non_run3_inputs():
+    jets = ak.Array([[{"pt": 10.0}, {"pt": 20.0}]])
+
+    selected = get_veto_map_input_jets(jets, "2018", False)
+
+    assert ak.to_list(selected.pt) == [[10.0, 20.0]]

--- a/topeft/channels/ch_lst.json
+++ b/topeft/channels/ch_lst.json
@@ -1374,13 +1374,13 @@
                 ],
                 [
                     "3l_1tau_1b",
-		    "3l",
+		            "3l",
                     "bmask_exactly1m",
                     "1tau"
                 ],
                 [
                     "3l_1tau_2b",
-		    "3l",
+		            "3l",
                     "bmask_atleast2m",
                     "1tau"
                 ]

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -176,6 +176,9 @@ def get_jerc_keys(year, isdata, era=None, corr_type="jets"):
     if corr_type == "type1_met":
         type1_levels_key = "type1_jec_levels_data" if isdata else "type1_jec_levels_mc"
         jec_levels = jerc_dict[year].get(type1_levels_key, jec_levels)
+    elif corr_type == "jets":
+        levels_key = "jec_levels_data" if isdata else "jec_levels_mc"
+        jec_levels = jerc_dict[year].get(levels_key, jec_levels)
 
     # jerc keys and junc types
     if not isdata:

--- a/topeft/modules/jerc_dict.yml
+++ b/topeft/modules/jerc_dict.yml
@@ -7,6 +7,15 @@
   jec_levels:
     - L1FastJet
     - L2Relative
+  jec_levels_mc:
+    - L1FastJet
+    - L2Relative
+    - L3Absolute
+  jec_levels_data:
+    - L1FastJet
+    - L2Relative
+    - L3Absolute
+    - L2L3Residual
   type1_jec_levels_mc:
     - L1FastJet
     - L2Relative
@@ -39,6 +48,15 @@
   jec_levels:
     - L1FastJet
     - L2Relative
+  jec_levels_mc:
+    - L1FastJet
+    - L2Relative
+    - L3Absolute
+  jec_levels_data:
+    - L1FastJet
+    - L2Relative
+    - L3Absolute
+    - L2L3Residual
   type1_jec_levels_mc:
     - L1FastJet
     - L2Relative
@@ -71,6 +89,15 @@
   jec_levels:
     - L1FastJet
     - L2Relative
+  jec_levels_mc:
+    - L1FastJet
+    - L2Relative
+    - L3Absolute
+  jec_levels_data:
+    - L1FastJet
+    - L2Relative
+    - L3Absolute
+    - L2L3Residual
   type1_jec_levels_mc:
     - L1FastJet
     - L2Relative
@@ -102,6 +129,15 @@
   jec_levels:
     - L1FastJet
     - L2Relative
+  jec_levels_mc:
+    - L1FastJet
+    - L2Relative
+    - L3Absolute
+  jec_levels_data:
+    - L1FastJet
+    - L2Relative
+    - L3Absolute
+    - L2L3Residual
   type1_jec_levels_mc:
     - L1FastJet
     - L2Relative


### PR DESCRIPTION
### Summary

* Align Run 2 regular AK4 CHS jet JEC correction levels with the full UL sequence for MC and data.
* Add Run 3 jet-veto-map input selection using corrected/smeared jets after JEC/JER systematics are applied.
* Preserve Run 2 jet-veto-map behavior as disabled, while keeping Type-1 MET correction behavior unchanged.
* Add targeted tests for Run 2/Run 3 JEC-level policy, Run 3 veto-map input selection, and processor ordering.
* Update Run 3/Run 2 sample and CR-running configuration used by the analysis workflow.

### Motivation

The JME object-review checks identified two jet/MET handling issues in the analysis framework.

First, regular Run 2 analysis jets were still using the inherited reduced JEC correction level list for jet corrections. Type-1 MET had already been configured with the full MC/data JEC-level convention, but regular analysis jets needed the same Run 2 UL-aligned treatment: `L1FastJet`, `L2Relative`, and `L3Absolute` for MC, plus `L2L3Residual` for data.

Second, Run 3 jet veto maps were being evaluated on lepton/tau-cleaned jets before the JEC/JER correction and object-systematic sequence. The JME-recommended ordering is to apply the veto-map decision on corrected/smeared jets. This matters because the veto-map input selection is based on jet pT and should use the corrected/smeared pT for the current object-systematic scenario.

The workflow/config updates in this branch also capture the current CR production setup and sample-list adjustments needed by the ongoing Run 2/Run 3 analysis validation.

### Implementation details

#### A. Run 2 regular jet JEC levels

Updated the JEC configuration and key lookup so regular Run 2 analysis jets can use MC/data-specific correction level lists.

Changed files:

* `topeft/modules/jerc_dict.yml`
* `topeft/modules/corrections.py`
* `tests/test_met_collection_policy.py`

For Run 2 regular analysis jets, the configured levels are now:

```text
MC:
  L1FastJet
  L2Relative
  L3Absolute

Data:
  L1FastJet
  L2Relative
  L3Absolute
  L2L3Residual
```

The `get_jerc_keys(..., corr_type="jets")` path now checks for `jec_levels_mc` or `jec_levels_data` when available, while preserving the existing `type1_met` override path.

Run 3 JEC-level behavior is covered by tests and remains unchanged.

#### B. Run 3 jet-veto-map input selection

Added a dedicated helper in `analysis/topeft_run2/analysis_processor.py`:

```python
def get_veto_map_input_jets(cleaned_jets, year, is_run3):
    if not is_run3:
        return cleaned_jets

    jet_id_mask = tc_os.run3_nanoV12_ak4puppi_jet_id(
        cleaned_jets,
        year,
        working_point="tight_lepton_veto",
    )
    em_fraction_mask = (cleaned_jets.chEmEF + cleaned_jets.neEmEF) < 0.9
    return cleaned_jets[
        (cleaned_jets.pt > 15.0)
        & jet_id_mask
        & em_fraction_mask
    ]
```

For Run 3, the veto-map input jets now satisfy:

```text
corrected/smeared pt > 15 GeV
tight-lepton-veto-equivalent Run 3 AK4 PUPPI jet ID
chEmEF + neEmEF < 0.9
```

For non-Run-3 years, the helper returns the input jet collection unchanged.

#### C. Run 3 jet-veto-map ordering

Moved the Run 3 jet-veto-map evaluation in `analysis_processor.py` from before the correction sequence to after:

```python
cleanedJets = ApplyJetCorrections(...).build(cleanedJets, lazy_cache=events_cache)
cleanedJets = ApplyJetSystematics(year, cleanedJets, syst_var)
```

The new order is:

```text
lepton/tau cleaning
raw-field attachment
JEC/JER correction factory
current object systematic variation
Run 3 jet-veto-map input selection
Run 3 jet-veto-map event veto
analysis jet selection
```

This keeps the veto-map evaluation inside the existing object-systematic loop, so JES/JER variations can consistently affect the veto decision through the corrected/smeared jet pT.

Run 2 remains disabled for jet veto maps through the existing `is_run3` guard:

```python
veto_map_array = ApplyJetVetoMaps(veto_map_input_jets, year) if is_run3 else ak.zeros_like(met.pt)
```

#### D. Type-1 MET behavior

No Type-1 MET code path was changed.

The Type-1 MET policy tests were updated/run to confirm that the JEC-level conventions remain explicit for Run 2 and Run 3.

#### E. Tests

Added `tests/test_run3_veto_map_input_selection.py`, covering:

* Run 3 minimal veto-map input selection.
* Use of the received jet `pt` field rather than `pt_raw`.
* Veto-map input selection remaining looser than final analysis jet selection.
* Non-Run-3 passthrough behavior.
* Processor source ordering: veto maps are evaluated after `ApplyJetCorrections(...)` and `ApplyJetSystematics(...)`.
* Run 2 veto-map application remains disabled.

Updated `tests/test_met_collection_policy.py`, covering:

* Run 2 regular MC jet JEC levels use `L1FastJet`, `L2Relative`, `L3Absolute`.
* Run 2 regular data jet JEC levels include `L2L3Residual`.
* Run 3 regular jet JEC levels remain unchanged.

#### F. Workflow and sample configuration updates

The branch also includes analysis workflow/configuration updates:

* `analysis/topeft_run2/fullR3_run.sh`
* `analysis/topeft_run2/run_cr.sh`
* `analysis/topeft_run2/make_skim_jsons.py`
* `analysis/topeft_run2/run_analysis.py`
* `input_samples/cfgs/*`
* `topeft/channels/ch_lst.json`

These changes update the active CR production setup, sample cfg coverage, NDSkim JSON naming, and small channel/config formatting details used in the current validation workflow.

### Testing

Targeted validation for the JME/JVM changes:

```bash
/users/apiccine/work/correction-lib/codex-run.sh /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && /users/apiccine/work/miniconda3/envs/clib-env/bin/python -m compileall analysis/topeft_run2/analysis_processor.py topeft/modules/corrections.py'
```

Result: passed.

```bash
/users/apiccine/work/correction-lib/codex-run.sh /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && /users/apiccine/work/miniconda3/envs/clib-env/bin/python -m pytest -q tests/test_run3_veto_map_input_selection.py'
```

Result: `6 passed, 1 warning`.

```bash
/users/apiccine/work/correction-lib/codex-run.sh /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && /users/apiccine/work/miniconda3/envs/clib-env/bin/python -m pytest -q tests/test_met_collection_policy.py'
```

Result: `44 passed, 1 warning`.

```bash
/users/apiccine/work/correction-lib/codex-run.sh /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && /users/apiccine/work/miniconda3/envs/clib-env/bin/python -m compileall analysis tests'
```

Result: passed.

Full-suite check:

```bash
/users/apiccine/work/correction-lib/codex-run.sh /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && /users/apiccine/work/miniconda3/envs/clib-env/bin/python -m pytest -q'
```

Result: failed with broad pre-existing/nonlocal failures: `42 failed, 559 passed, 1 skipped, 10 warnings`.

The failures are not in `tests/test_run3_veto_map_input_selection.py` or `tests/test_met_collection_policy.py`. They are broader branch/workspace issues involving missing fixtures/artifacts, SparseHist pickle compatibility, channel metadata expectations, Work Queue/yield prerequisites, and run-analysis CLI test expectations.

### Review notes

* The main physics/analysis semantic changes are:

  * Run 2 regular analysis jets now use the full UL JEC correction level sequence.
  * Run 3 jet veto maps are evaluated after JEC/JER and the current JES/JER object variation.
  * Run 3 veto-map event rejection can therefore be scenario-dependent for object-systematic variations.

* Reviewers should check that the Run 3 JVM ordering is the intended JME behavior:

  * lepton/tau-cleaned jets,
  * corrected/smeared pT,
  * `pt > 15 GeV`,
  * tight-lepton-veto-equivalent AK4 PUPPI jet ID,
  * `chEmEF + neEmEF < 0.9`.

* Reviewers should also check whether the workflow/configuration changes in `run_cr.sh`, `fullR3_run.sh`, and `input_samples/cfgs/*` should remain in this PR or be split from the JME correction/JVM logic.

* The full test suite is not clean on this branch. The targeted tests for the changed JME/JVM and MET policy surfaces pass, but the broader failures should be triaged separately before production freezing.